### PR TITLE
fix/theme appearance selector issue

### DIFF
--- a/iExpense/ViewModels/SettingsViewModel.swift
+++ b/iExpense/ViewModels/SettingsViewModel.swift
@@ -95,20 +95,11 @@ class SettingsViewModel: ObservableObject {
             sharedDefaults?.synchronize()
         }
         
-        // Load other settings from standard UserDefaults
-        if let savedCategoryString = UserDefaults.standard.string(forKey: "defaultCategory"),
-           let savedCategory = Category(rawValue: savedCategoryString) {
-            self.defaultCategory = savedCategory
-        } else {
-            self.defaultCategory = .food
-        }
+        let savedCategory = UserDefaults.standard.string(forKey: "defaultCategory")
+        self.defaultCategory = Category(rawValue: savedCategory ?? "food") ?? .food
         
-        if let savedThemeString = UserDefaults.standard.string(forKey: "selectedTheme"),
-           let savedTheme = AppTheme(rawValue: savedThemeString) {
-            self.selectedTheme = savedTheme
-        } else {
-            self.selectedTheme = .system
-        }
+        let savedTheme = UserDefaults.standard.string(forKey: "selectedTheme")
+        self.selectedTheme = AppTheme(rawValue: savedTheme ?? "system") ?? .system
     }
     
     func exportData() -> URL? {
@@ -175,4 +166,4 @@ func getSettingsCurrencySymbol() -> String {
         return currency.symbol
     }
     return "$" // Default fallback
-} 
+}

--- a/iExpense/Views/MainTabView.swift
+++ b/iExpense/Views/MainTabView.swift
@@ -11,8 +11,7 @@ import SwiftData
 struct MainTabView: View {
     @StateObject private var viewModel = ExpenseViewModel()
     @StateObject private var analyticsViewModel = AnalyticsViewModel(expenses: [])
-    @StateObject private var settingsViewModel = SettingsViewModel()
-    @State private var colorScheme: ColorScheme?
+    @EnvironmentObject private var settingsViewModel: SettingsViewModel
     @State private var selectedTab = 0
 
     var body: some View {
@@ -43,10 +42,9 @@ struct MainTabView: View {
                     .tag(3)
             }
         }
-        .preferredColorScheme(colorScheme)
+        .preferredColorScheme(settingsViewModel.selectedTheme.colorScheme)
         .onAppear {
             analyticsViewModel.updateExpenses(viewModel.expenses)
-            updateColorScheme()
             
             // Register for the notification to switch tabs
             NotificationCenter.default.addObserver(forName: NSNotification.Name("SwitchToExpensesTab"), object: nil, queue: .main) { _ in
@@ -56,16 +54,10 @@ struct MainTabView: View {
         .onChange(of: viewModel.expenses) {
             analyticsViewModel.updateExpenses(viewModel.expenses)
         }
-        .onChange(of: settingsViewModel.selectedTheme) {
-            updateColorScheme()
-        }
-    }
-    
-    private func updateColorScheme() {
-        colorScheme = settingsViewModel.selectedTheme.colorScheme
     }
 }
 
 #Preview {
     MainTabView()
+        .environmentObject(SettingsViewModel())
 }

--- a/iExpense/Views/SettingsView.swift
+++ b/iExpense/Views/SettingsView.swift
@@ -7,7 +7,8 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct SettingsView: View {
-    @StateObject private var viewModel = SettingsViewModel()
+    @EnvironmentObject var settingsManager: SettingsViewModel
+    
     @State private var showingImportFilePicker = false
     @State private var showingExportShareSheet = false
     @State private var exportURL: URL? = nil
@@ -73,7 +74,7 @@ struct SettingsView: View {
     }
     
     private var themePicker: some View {
-        Picker("Theme", selection: $viewModel.selectedTheme) {
+        Picker("Theme", selection: $settingsManager.selectedTheme) {
             ForEach(AppTheme.allCases) { theme in
                 Text(theme.displayName).tag(theme)
             }
@@ -88,7 +89,7 @@ struct SettingsView: View {
     }
     
     private var currencyPicker: some View {
-        Picker("Currency", selection: $viewModel.selectedCurrency) {
+        Picker("Currency", selection: $settingsManager.selectedCurrency) {
             ForEach(availableCurrencies, id: \.code) { currency in
                 currencyRow(for: currency)
             }
@@ -108,7 +109,7 @@ struct SettingsView: View {
     }
     
     private var categoryPicker: some View {
-        Picker("Default Category", selection: $viewModel.defaultCategory) {
+        Picker("Default Category", selection: $settingsManager.defaultCategory) {
             ForEach(Category.allCases, id: \.self) { category in
                 categoryRow(for: category)
             }
@@ -179,7 +180,7 @@ struct SettingsView: View {
             allowsMultipleSelection: false
         ) { urls in
             guard let url = urls.first else { return }
-            let success = viewModel.importData(from: url)
+            let success = settingsManager.importData(from: url)
             if success {
                 showingImportSuccess = true
             } else {
@@ -200,13 +201,13 @@ struct SettingsView: View {
         Group {
             Button("Cancel", role: .cancel) { }
             Button("Reset", role: .destructive) {
-                viewModel.resetAllData()
+                settingsManager.resetAllData()
             }
         }
     }
     
     private func exportData() {
-        if let url = viewModel.exportData() {
+        if let url = settingsManager.exportData() {
             exportURL = url
             showingExportShareSheet = true
             showingExportSuccess = true
@@ -260,4 +261,5 @@ struct ShareSheet: UIViewControllerRepresentable {
 
 #Preview {
     SettingsView()
+        .environmentObject(SettingsViewModel())
 }

--- a/iExpense/iExpenseApp.swift
+++ b/iExpense/iExpenseApp.swift
@@ -15,6 +15,8 @@ struct iExpenseApp: App {
         syncSettingsToSharedDefaults()
     }
     
+    @StateObject private var settingsViewModel = SettingsViewModel()
+    
     var body: some Scene {
         WindowGroup {
             MainTabView()
@@ -24,6 +26,8 @@ struct iExpenseApp: App {
                 .task {
                     await SwiftDataProvider.shared.startMigration()
                 }
+                .environmentObject(settingsViewModel)
+                .preferredColorScheme(settingsViewModel.selectedTheme.colorScheme)
         }
     }
     


### PR DESCRIPTION
Theme selector was not working live. You were expected to refresh the app to apply the new theme appearance
fixed by propagating the settingsViewModel in `@main` and attaching a `preferredColorScheme` to the app that fetched the scheme from the model