### PR TITLE
Add income cashflow tracking and custom categories

### DIFF
--- a/Inpenso.xcodeproj/project.pbxproj
+++ b/Inpenso.xcodeproj/project.pbxproj
@@ -422,7 +422,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragomir.Inpenso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -458,7 +458,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragomir.Inpenso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -490,7 +490,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragomir.Inpenso.iExpenseWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -519,7 +519,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragomir.Inpenso.iExpenseWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Inpenso.xcodeproj/project.pbxproj
+++ b/Inpenso.xcodeproj/project.pbxproj
@@ -422,7 +422,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragomir.Inpenso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -458,7 +458,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragomir.Inpenso;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -490,7 +490,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragomir.Inpenso.iExpenseWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -519,7 +519,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragomir.Inpenso.iExpenseWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/iExpense/Components/Analytics/BudgetView.swift
+++ b/iExpense/Components/Analytics/BudgetView.swift
@@ -211,7 +211,9 @@ struct BudgetStatusView: View {
 
 /// A component that displays budget recommendations
 struct BudgetRecommendationsView: View {
-    let biggestExpenseCategory: (category: Category, amount: Double)?
+    @EnvironmentObject private var categoryStore: CategoryStore
+
+    let biggestExpenseCategory: (categoryID: String, amount: Double)?
     let totalSpent: Double
     let currentBudget: Double
     let daysRemainingInMonth: Int
@@ -219,7 +221,7 @@ struct BudgetRecommendationsView: View {
     let currencyCode: String
     
     init(
-        biggestExpenseCategory: (category: Category, amount: Double)?,
+        biggestExpenseCategory: (categoryID: String, amount: Double)?,
         totalSpent: Double,
         currentBudget: Double,
         daysRemainingInMonth: Int,
@@ -241,8 +243,10 @@ struct BudgetRecommendationsView: View {
             
             VStack(spacing: 16) {
                 // Recommend categories to cut
-                if let (category, amount) = biggestExpenseCategory, 
+                if let (categoryID, amount) = biggestExpenseCategory,
                    totalSpent > currentBudget {
+                    let category = categoryStore.category(for: categoryID)
+
                     HStack {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Consider Reducing")
@@ -410,12 +414,13 @@ struct BudgetHistoryView: View {
         
         // Budget Recommendations preview
         BudgetRecommendationsView(
-            biggestExpenseCategory: (Category.food, 450.50),
+            biggestExpenseCategory: (Category.food.categoryID, 450.50),
             totalSpent: 1875.50,
             currentBudget: 2500.00,
             daysRemainingInMonth: 14,
             suggestedBudget: 2700.00
         )
+        .environmentObject(CategoryStore())
         
         // Budget History preview
         BudgetHistoryView(complianceData: [

--- a/iExpense/Components/Analytics/CategoryBreakdownView.swift
+++ b/iExpense/Components/Analytics/CategoryBreakdownView.swift
@@ -10,12 +10,14 @@ import Charts
 
 /// A component that displays spending breakdown by category
 struct CategoryBreakdownView: View {
-    let spendingByCategory: [Category: Double]
+    @EnvironmentObject private var categoryStore: CategoryStore
+
+    let spendingByCategory: [String: Double]
     let totalSpent: Double
     let currencyCode: String
     
     init(
-        spendingByCategory: [Category: Double],
+        spendingByCategory: [String: Double],
         totalSpent: Double,
         currencyCode: String? = nil
     ) {
@@ -38,7 +40,8 @@ struct CategoryBreakdownView: View {
                 VStack {
                     // Pie chart
                     Chart {
-                        ForEach(spendingByCategory.sorted(by: { $0.value > $1.value }), id: \.key) { category, amount in
+                        ForEach(spendingByCategory.sorted(by: { $0.value > $1.value }), id: \.key) { categoryID, amount in
+                            let category = categoryStore.category(for: categoryID)
                             SectorMark(
                                 angle: .value("Amount", amount),
                                 innerRadius: .ratio(0.6),
@@ -52,8 +55,8 @@ struct CategoryBreakdownView: View {
                     
                     // Category legend
                     VStack(spacing: 8) {
-                        ForEach(spendingByCategory.sorted(by: { $0.value > $1.value }), id: \.key) { category, amount in
-                            categoryRow(category: category, amount: amount)
+                        ForEach(spendingByCategory.sorted(by: { $0.value > $1.value }), id: \.key) { categoryID, amount in
+                            categoryRow(category: categoryStore.category(for: categoryID), amount: amount)
                         }
                     }
                     .padding(.top, 8)
@@ -67,7 +70,7 @@ struct CategoryBreakdownView: View {
         )
     }
     
-    private func categoryRow(category: Category, amount: Double) -> some View {
+    private func categoryRow(category: FinanceCategory, amount: Double) -> some View {
         HStack {
             // Color indicator
             Circle()
@@ -99,17 +102,18 @@ struct CategoryBreakdownView: View {
 }
 
 #Preview {
-    let sampleData: [Category: Double] = [
-        .food: 450.50,
-        .transportation: 220.75,
-        .rent: 1200.00,
-        .entertainment: 180.25,
-        .utilities: 310.80
+    let sampleData: [String: Double] = [
+        Category.food.categoryID: 450.50,
+        Category.transportation.categoryID: 220.75,
+        Category.rent.categoryID: 1200.00,
+        Category.entertainment.categoryID: 180.25,
+        Category.utilities.categoryID: 310.80
     ]
     
     CategoryBreakdownView(
         spendingByCategory: sampleData,
         totalSpent: sampleData.values.reduce(0, +)
     )
+    .environmentObject(CategoryStore())
     .padding()
 } 

--- a/iExpense/Components/Analytics/InsightsView.swift
+++ b/iExpense/Components/Analytics/InsightsView.swift
@@ -15,13 +15,15 @@ extension SpendingInsight: Identifiable {
 
 /// A component that displays key spending statistics
 struct KeyStatisticsView: View {
-    let biggestExpenseCategory: (category: Category, amount: Double)?
+    @EnvironmentObject private var categoryStore: CategoryStore
+
+    let biggestExpenseCategory: (categoryID: String, amount: Double)?
     let totalSpent: Double
     let mostActiveSpendingPeriod: String?
     let currencyCode: String
     
     init(
-        biggestExpenseCategory: (category: Category, amount: Double)?,
+        biggestExpenseCategory: (categoryID: String, amount: Double)?,
         totalSpent: Double,
         mostActiveSpendingPeriod: String?,
         currencyCode: String? = nil
@@ -38,7 +40,9 @@ struct KeyStatisticsView: View {
                 .font(.headline)
             
             // Biggest expense category
-            if let (category, amount) = biggestExpenseCategory {
+            if let (categoryID, amount) = biggestExpenseCategory {
+                let category = categoryStore.category(for: categoryID)
+
                 HStack {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Top Spending Category")
@@ -250,10 +254,11 @@ struct SpendingPatternView: View {
     VStack(spacing: 20) {
         // Key Statistics preview
         KeyStatisticsView(
-            biggestExpenseCategory: (Category.food, 450.50),
+            biggestExpenseCategory: (Category.food.categoryID, 450.50),
             totalSpent: 1850.25,
             mostActiveSpendingPeriod: "Wednesday"
         )
+        .environmentObject(CategoryStore())
         
         // Insights preview
         InsightsCardView(insights: [

--- a/iExpense/Components/Analytics/MonthlyTrendsView.swift
+++ b/iExpense/Components/Analytics/MonthlyTrendsView.swift
@@ -98,8 +98,8 @@ struct MonthlyTrendsView: View {
 /// A component that displays category trend information
 struct CategoryTrendsView: View {
     struct CategoryTrend: Identifiable {
-        var id: String { "\(category.rawValue)-\(month)-\(year)" }
-        let category: Category
+        var id: String { "\(categoryID)-\(month)-\(year)" }
+        let categoryID: String
         let month: Int
         let year: Int
         let currentAmount: Double
@@ -113,6 +113,8 @@ struct CategoryTrendsView: View {
         }
     }
     
+    @EnvironmentObject private var categoryStore: CategoryStore
+
     let categoryTrends: [CategoryTrend]
     let currencyCode: String
     
@@ -155,13 +157,15 @@ struct CategoryTrendsView: View {
     }
     
     private func categoryTrendRow(trend: CategoryTrend) -> some View {
-        HStack {
+        let category = categoryStore.category(for: trend.categoryID)
+
+        return HStack {
             // Category color and name
             Circle()
-                .fill(trend.category.color)
+                .fill(category.color)
                 .frame(width: 12, height: 12)
             
-            Text(trend.category.displayName)
+            Text(category.displayName)
                 .font(.subheadline)
             
             Spacer()
@@ -290,21 +294,21 @@ struct ProjectionView: View {
         // Category trends preview
         let categoryTrends = [
             CategoryTrendsView.CategoryTrend(
-                category: .food,
+                categoryID: Category.food.categoryID,
                 month: 5,
                 year: 2025,
                 currentAmount: 450.50,
                 previousAmount: 380.25
             ),
             CategoryTrendsView.CategoryTrend(
-                category: .transportation,
+                categoryID: Category.transportation.categoryID,
                 month: 5,
                 year: 2025,
                 currentAmount: 220.75,
                 previousAmount: 280.50
             ),
             CategoryTrendsView.CategoryTrend(
-                category: .entertainment,
+                categoryID: Category.entertainment.categoryID,
                 month: 5,
                 year: 2025,
                 currentAmount: 180.25,
@@ -313,6 +317,7 @@ struct ProjectionView: View {
         ]
         
         CategoryTrendsView(categoryTrends: categoryTrends)
+            .environmentObject(CategoryStore())
         
         // Projection preview
         ProjectionView(

--- a/iExpense/Components/CategoryButton.swift
+++ b/iExpense/Components/CategoryButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CategoryButton: View {
-    let category: Category
+    let category: FinanceCategory
     let isSelected: Bool
     let action: () -> Void
     
@@ -58,12 +58,12 @@ struct CategoryButton: View {
 #Preview(traits: .sizeThatFitsLayout) {
     HStack(spacing: 20) {
         CategoryButton(
-            category: .food,
+            category: FinanceCategory.builtIn(for: .food),
             isSelected: true,
             action: {}
         )
         CategoryButton(
-            category: .transportation,
+            category: FinanceCategory.builtIn(for: .transportation),
             isSelected: false,
             action: {}
         )

--- a/iExpense/Components/CategoryGrid.swift
+++ b/iExpense/Components/CategoryGrid.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct CategoryGrid: View {
-    @Binding var selectedCategory: Category
+    @Binding var selectedCategoryID: String
+    let categories: [FinanceCategory]
     var onCategorySelected: (() -> Void)? = nil
     
     // Number of columns in the grid
@@ -20,13 +21,13 @@ struct CategoryGrid: View {
     
     var body: some View {
         LazyVGrid(columns: columns, spacing: 15) {
-            ForEach(Category.allCases, id: \.self) { category in
+            ForEach(categories) { category in
                 CategoryButton(
                     category: category,
-                    isSelected: selectedCategory == category,
+                    isSelected: selectedCategoryID == category.id,
                     action: {
                         withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-                            selectedCategory = category
+                            selectedCategoryID = category.id
                         }
                         HapticFeedback.impact()
                         onCategorySelected?()
@@ -40,8 +41,9 @@ struct CategoryGrid: View {
 
 // An alternative version with a manual callback for cases where binding isn't appropriate
 struct CategoryGridWithCallback: View {
-    let selectedCategory: Category
-    let onCategorySelected: (Category) -> Void
+    let selectedCategoryID: String
+    let categories: [FinanceCategory]
+    let onCategorySelected: (FinanceCategory) -> Void
     
     // Number of columns in the grid
     private let columns = [
@@ -52,10 +54,10 @@ struct CategoryGridWithCallback: View {
     
     var body: some View {
         LazyVGrid(columns: columns, spacing: 15) {
-            ForEach(Category.allCases, id: \.self) { category in
+            ForEach(categories) { category in
                 CategoryButton(
                     category: category,
-                    isSelected: selectedCategory == category,
+                    isSelected: selectedCategoryID == category.id,
                     action: {
                         HapticFeedback.impact()
                         onCategorySelected(category)
@@ -73,7 +75,10 @@ struct CategoryGridWithCallback: View {
             .font(.headline)
             .padding()
         
-        CategoryGrid(selectedCategory: .constant(.food))
+        CategoryGrid(
+            selectedCategoryID: .constant(Category.food.categoryID),
+            categories: FinanceCategory.builtInCategories
+        )
             .padding()
             .background(Color(.secondarySystemBackground))
             .cornerRadius(12)

--- a/iExpense/Models/Category.swift
+++ b/iExpense/Models/Category.swift
@@ -210,6 +210,40 @@ struct FinanceCategory: Identifiable, Codable, Equatable, Hashable {
     }
 }
 
+struct CategoryCatalogState: Codable, Equatable {
+    var orderedCategoryIDs: [String]
+    var customCategories: [FinanceCategory]
+    var builtInOverrides: [String: FinanceCategory]
+    var hiddenCategoryIDs: Set<String>
+
+    init(
+        orderedCategoryIDs: [String] = [],
+        customCategories: [FinanceCategory] = [],
+        builtInOverrides: [String: FinanceCategory] = [:],
+        hiddenCategoryIDs: Set<String> = []
+    ) {
+        self.orderedCategoryIDs = orderedCategoryIDs
+        self.customCategories = customCategories
+        self.builtInOverrides = builtInOverrides
+        self.hiddenCategoryIDs = hiddenCategoryIDs
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case orderedCategoryIDs
+        case customCategories
+        case builtInOverrides
+        case hiddenCategoryIDs
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        orderedCategoryIDs = try container.decodeIfPresent([String].self, forKey: .orderedCategoryIDs) ?? []
+        customCategories = try container.decodeIfPresent([FinanceCategory].self, forKey: .customCategories) ?? []
+        builtInOverrides = try container.decodeIfPresent([String: FinanceCategory].self, forKey: .builtInOverrides) ?? [:]
+        hiddenCategoryIDs = try container.decodeIfPresent(Set<String>.self, forKey: .hiddenCategoryIDs) ?? []
+    }
+}
+
 extension Color {
     init?(hex: String) {
         var sanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/iExpense/Models/Category.swift
+++ b/iExpense/Models/Category.swift
@@ -9,6 +9,31 @@ import Foundation
 import AppIntents
 import SwiftUI
 
+enum TransactionType: String, CaseIterable, Codable, Identifiable {
+    case expense
+    case income
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .expense:
+            return "Expense"
+        case .income:
+            return "Income"
+        }
+    }
+
+    var amountColor: Color {
+        switch self {
+        case .expense:
+            return .primary
+        case .income:
+            return .green
+        }
+    }
+}
+
 enum Category: String, CaseIterable, Codable, AppEnum {
     case food
     case eatingOut
@@ -56,6 +81,69 @@ enum Category: String, CaseIterable, Codable, AppEnum {
 }
 
 extension Category {
+    var categoryID: String {
+        "builtin-\(rawValue)"
+    }
+
+    static func category(from id: String) -> Category? {
+        guard id.hasPrefix("builtin-") else { return nil }
+        return Category(rawValue: String(id.dropFirst("builtin-".count)))
+    }
+
+    var defaultIconName: String {
+        switch self {
+        case .food:
+            return "cart.fill"
+        case .eatingOut:
+            return "fork.knife"
+        case .rent:
+            return "house.fill"
+        case .shopping:
+            return "bag.fill"
+        case .entertainment:
+            return "tv.fill"
+        case .transportation:
+            return "car.fill"
+        case .utilities:
+            return "bolt.fill"
+        case .subscriptions:
+            return "repeat"
+        case .healthcare:
+            return "heart.fill"
+        case .education:
+            return "book.fill"
+        case .others:
+            return "ellipsis"
+        }
+    }
+
+    var defaultColorHex: String {
+        switch self {
+        case .food:
+            return "#34C759"
+        case .eatingOut:
+            return "#00C7BE"
+        case .rent:
+            return "#AF52DE"
+        case .shopping:
+            return "#FF9500"
+        case .entertainment:
+            return "#FF2D55"
+        case .transportation:
+            return "#007AFF"
+        case .utilities:
+            return "#FFCC00"
+        case .subscriptions:
+            return "#30B0C7"
+        case .healthcare:
+            return "#FF3B30"
+        case .education:
+            return "#5856D6"
+        case .others:
+            return "#8E8E93"
+        }
+    }
+
     var color: Color {
         switch self {
         case .food:
@@ -84,3 +172,57 @@ extension Category {
     }
 }
 
+struct FinanceCategory: Identifiable, Codable, Equatable, Hashable {
+    var id: String
+    var name: String
+    var iconName: String
+    var colorHex: String
+    var isCustom: Bool
+
+    var displayName: String { name }
+
+    var color: Color {
+        Color(hex: colorHex) ?? .gray
+    }
+
+    static let builtInCategories: [FinanceCategory] = Category.allCases.map { category in
+        FinanceCategory(
+            id: category.categoryID,
+            name: category.displayName,
+            iconName: category.defaultIconName,
+            colorHex: category.defaultColorHex,
+            isCustom: false
+        )
+    }
+
+    static func builtIn(for category: Category) -> FinanceCategory {
+        FinanceCategory(
+            id: category.categoryID,
+            name: category.displayName,
+            iconName: category.defaultIconName,
+            colorHex: category.defaultColorHex,
+            isCustom: false
+        )
+    }
+
+    static var fallback: FinanceCategory {
+        builtIn(for: .others)
+    }
+}
+
+extension Color {
+    init?(hex: String) {
+        var sanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        sanitized = sanitized.replacingOccurrences(of: "#", with: "")
+
+        guard sanitized.count == 6,
+              let value = Int(sanitized, radix: 16) else {
+            return nil
+        }
+
+        let red = Double((value >> 16) & 0xFF) / 255.0
+        let green = Double((value >> 8) & 0xFF) / 255.0
+        let blue = Double(value & 0xFF) / 255.0
+        self.init(red: red, green: green, blue: blue)
+    }
+}

--- a/iExpense/Models/CategoryStore.swift
+++ b/iExpense/Models/CategoryStore.swift
@@ -1,0 +1,60 @@
+//
+//  CategoryStore.swift
+//  iExpense
+//
+
+import SwiftUI
+
+@MainActor
+final class CategoryStore: ObservableObject {
+    @Published private(set) var customCategories: [FinanceCategory] = []
+
+    var allCategories: [FinanceCategory] {
+        FinanceCategory.builtInCategories + customCategories
+    }
+
+    init() {
+        customCategories = StorageService.loadCustomCategories()
+    }
+
+    func category(for id: String) -> FinanceCategory {
+        allCategories.first { $0.id == id } ?? FinanceCategory.fallback
+    }
+
+    func category(for transaction: Expense) -> FinanceCategory {
+        category(for: transaction.categoryID)
+    }
+
+    func addCategory(name: String, iconName: String, colorHex: String) {
+        let category = FinanceCategory(
+            id: "custom-\(UUID().uuidString)",
+            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+            iconName: iconName,
+            colorHex: colorHex,
+            isCustom: true
+        )
+        customCategories.append(category)
+        save()
+    }
+
+    func updateCategory(_ category: FinanceCategory) {
+        guard category.isCustom,
+              let index = customCategories.firstIndex(where: { $0.id == category.id }) else {
+            return
+        }
+
+        customCategories[index] = category
+        save()
+    }
+
+    func deleteCategory(_ category: FinanceCategory) {
+        guard category.isCustom else { return }
+        customCategories.removeAll { $0.id == category.id }
+        save()
+    }
+
+    private func save() {
+        StorageService.saveCustomCategories(customCategories)
+    }
+}
+

--- a/iExpense/Models/CategoryStore.swift
+++ b/iExpense/Models/CategoryStore.swift
@@ -7,22 +7,83 @@ import SwiftUI
 
 @MainActor
 final class CategoryStore: ObservableObject {
-    @Published private(set) var customCategories: [FinanceCategory] = []
+    @Published private var catalogState: CategoryCatalogState
+
+    var customCategories: [FinanceCategory] {
+        catalogState.customCategories
+    }
 
     var allCategories: [FinanceCategory] {
-        FinanceCategory.builtInCategories + customCategories
+        visibleCategories
+    }
+
+    var visibleCategories: [FinanceCategory] {
+        orderedCategories(includeHidden: false)
+    }
+
+    var hiddenCategories: [FinanceCategory] {
+        orderedCategories(includeHidden: true)
+            .filter { catalogState.hiddenCategoryIDs.contains($0.id) }
     }
 
     init() {
-        customCategories = StorageService.loadCustomCategories()
+        if let savedCatalogState = StorageService.loadCategoryCatalogState() {
+            catalogState = Self.normalized(savedCatalogState)
+        } else {
+            catalogState = Self.initialState(customCategories: StorageService.loadCustomCategories())
+            save()
+        }
     }
 
     func category(for id: String) -> FinanceCategory {
-        allCategories.first { $0.id == id } ?? FinanceCategory.fallback
+        categoryMap[id] ?? FinanceCategory.fallback
     }
 
     func category(for transaction: Expense) -> FinanceCategory {
         category(for: transaction.categoryID)
+    }
+
+    func categoriesForPicker(including categoryID: String? = nil) -> [FinanceCategory] {
+        var categories = visibleCategories
+
+        if let categoryID,
+           !categoryID.isEmpty,
+           !categories.contains(where: { $0.id == categoryID }),
+           let category = categoryMap[categoryID] {
+            categories.append(category)
+        }
+
+        return categories
+    }
+
+    func categoriesForFilter(usedCategoryIDs: Set<String>) -> [FinanceCategory] {
+        let visible = visibleCategories
+        let visibleIDs = Set(visible.map(\.id))
+        let extraIDs = usedCategoryIDs.subtracting(visibleIDs)
+        let extraCategories = orderedCategoryIDs(for: extraIDs).compactMap { categoryMap[$0] }
+
+        return visible + extraCategories
+    }
+
+    func orderedCategoryIDs(for categoryIDs: Set<String>) -> [String] {
+        let orderedIDs = catalogState.orderedCategoryIDs.filter { categoryIDs.contains($0) }
+        let knownOrderedIDs = Set(orderedIDs)
+        let unorderedIDs = categoryIDs.subtracting(knownOrderedIDs)
+            .sorted {
+                category(for: $0).displayName.localizedCaseInsensitiveCompare(category(for: $1).displayName) == .orderedAscending
+            }
+
+        return orderedIDs + unorderedIDs
+    }
+
+    func preferredCategoryID(for categoryID: String?) -> String {
+        if let categoryID,
+           !catalogState.hiddenCategoryIDs.contains(categoryID),
+           categoryMap[categoryID] != nil {
+            return categoryID
+        }
+
+        return visibleCategories.first?.id ?? FinanceCategory.fallback.id
     }
 
     func addCategory(name: String, iconName: String, colorHex: String) {
@@ -33,28 +94,180 @@ final class CategoryStore: ObservableObject {
             colorHex: colorHex,
             isCustom: true
         )
-        customCategories.append(category)
+        catalogState.customCategories.append(category)
+        catalogState.orderedCategoryIDs.append(category.id)
         save()
     }
 
     func updateCategory(_ category: FinanceCategory) {
-        guard category.isCustom,
-              let index = customCategories.firstIndex(where: { $0.id == category.id }) else {
+        if category.isCustom {
+            guard let index = catalogState.customCategories.firstIndex(where: { $0.id == category.id }) else {
+                return
+            }
+
+            var customCategory = category
+            customCategory.isCustom = true
+            catalogState.customCategories[index] = customCategory
+        } else if Self.builtInCategoryIDs.contains(category.id) {
+            var builtInOverride = category
+            builtInOverride.isCustom = false
+            catalogState.builtInOverrides[category.id] = builtInOverride
+        } else {
             return
         }
 
-        customCategories[index] = category
         save()
     }
 
     func deleteCategory(_ category: FinanceCategory) {
-        guard category.isCustom else { return }
-        customCategories.removeAll { $0.id == category.id }
+        hideCategory(category)
+    }
+
+    func hideCategory(_ category: FinanceCategory) {
+        guard categoryMap[category.id] != nil,
+              !catalogState.hiddenCategoryIDs.contains(category.id),
+              visibleCategories.count > 1 else {
+            return
+        }
+
+        catalogState.hiddenCategoryIDs.insert(category.id)
         save()
     }
 
+    func restoreCategory(_ category: FinanceCategory) {
+        guard categoryMap[category.id] != nil else { return }
+
+        catalogState.hiddenCategoryIDs.remove(category.id)
+        if !catalogState.orderedCategoryIDs.contains(category.id) {
+            catalogState.orderedCategoryIDs.append(category.id)
+        }
+
+        save()
+    }
+
+    func moveCategory(_ sourceID: String, to destinationID: String) {
+        guard sourceID != destinationID,
+              catalogState.orderedCategoryIDs.contains(sourceID),
+              catalogState.orderedCategoryIDs.contains(destinationID) else {
+            return
+        }
+
+        catalogState.orderedCategoryIDs.removeAll { $0 == sourceID }
+
+        if let destinationIndex = catalogState.orderedCategoryIDs.firstIndex(of: destinationID) {
+            catalogState.orderedCategoryIDs.insert(sourceID, at: destinationIndex)
+        } else {
+            catalogState.orderedCategoryIDs.append(sourceID)
+        }
+
+        save()
+    }
+
+    func resetBuiltInOverride(for categoryID: String) {
+        guard Self.builtInCategoryIDs.contains(categoryID) else { return }
+        catalogState.builtInOverrides.removeValue(forKey: categoryID)
+        save()
+    }
+
+    func isHidden(_ categoryID: String) -> Bool {
+        catalogState.hiddenCategoryIDs.contains(categoryID)
+    }
+
+    func hasBuiltInOverride(for categoryID: String) -> Bool {
+        catalogState.builtInOverrides[categoryID] != nil
+    }
+
     private func save() {
-        StorageService.saveCustomCategories(customCategories)
+        catalogState = Self.normalized(catalogState)
+        StorageService.saveCategoryCatalogState(catalogState)
+        StorageService.saveCustomCategories(catalogState.customCategories)
+    }
+
+    private var categoryMap: [String: FinanceCategory] {
+        Dictionary(uniqueKeysWithValues: allKnownCategories.map { ($0.id, $0) })
+    }
+
+    private var allKnownCategories: [FinanceCategory] {
+        builtInCategories + catalogState.customCategories
+    }
+
+    private var builtInCategories: [FinanceCategory] {
+        FinanceCategory.builtInCategories.map { category in
+            catalogState.builtInOverrides[category.id] ?? category
+        }
+    }
+
+    private func orderedCategories(includeHidden: Bool) -> [FinanceCategory] {
+        let categoriesByID = categoryMap
+
+        return catalogState.orderedCategoryIDs.compactMap { categoryID in
+            guard includeHidden || !catalogState.hiddenCategoryIDs.contains(categoryID) else {
+                return nil
+            }
+
+            return categoriesByID[categoryID]
+        }
+    }
+
+    private static var builtInCategoryIDs: Set<String> {
+        Set(FinanceCategory.builtInCategories.map(\.id))
+    }
+
+    private static func initialState(customCategories: [FinanceCategory]) -> CategoryCatalogState {
+        let normalizedCustomCategories = customCategories.map { category in
+            var category = category
+            category.isCustom = true
+            return category
+        }
+
+        return CategoryCatalogState(
+            orderedCategoryIDs: FinanceCategory.builtInCategories.map(\.id) + normalizedCustomCategories.map(\.id),
+            customCategories: normalizedCustomCategories
+        )
+    }
+
+    private static func normalized(_ state: CategoryCatalogState) -> CategoryCatalogState {
+        let builtInIDs = builtInCategoryIDs
+        var normalized = state
+        var seenCustomIDs = Set<String>()
+
+        normalized.customCategories = normalized.customCategories.compactMap { category in
+            guard !builtInIDs.contains(category.id),
+                  !seenCustomIDs.contains(category.id) else {
+                return nil
+            }
+
+            seenCustomIDs.insert(category.id)
+            var category = category
+            category.isCustom = true
+            return category
+        }
+
+        normalized.builtInOverrides = normalized.builtInOverrides.reduce(into: [String: FinanceCategory]()) { result, item in
+            guard builtInIDs.contains(item.key) else { return }
+            var category = item.value
+            category.id = item.key
+            category.isCustom = false
+            result[item.key] = category
+        }
+
+        let knownCategoryIDs = FinanceCategory.builtInCategories.map(\.id) + normalized.customCategories.map(\.id)
+        let knownCategoryIDSet = Set(knownCategoryIDs)
+        var orderedCategoryIDs: [String] = []
+        var seenOrderedIDs = Set<String>()
+
+        for categoryID in normalized.orderedCategoryIDs where knownCategoryIDSet.contains(categoryID) && !seenOrderedIDs.contains(categoryID) {
+            orderedCategoryIDs.append(categoryID)
+            seenOrderedIDs.insert(categoryID)
+        }
+
+        for categoryID in knownCategoryIDs where !seenOrderedIDs.contains(categoryID) {
+            orderedCategoryIDs.append(categoryID)
+        }
+
+        normalized.orderedCategoryIDs = orderedCategoryIDs
+        normalized.hiddenCategoryIDs = normalized.hiddenCategoryIDs.intersection(knownCategoryIDSet)
+
+        return normalized
     }
 }
-

--- a/iExpense/Models/Expense.swift
+++ b/iExpense/Models/Expense.swift
@@ -13,4 +13,51 @@ struct Expense: Identifiable, Codable, Equatable {
     var price: Double
     var date: Date
     var category: Category
+    var type: TransactionType
+    var categoryID: String
+    var notes: String?
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        price: Double,
+        date: Date,
+        category: Category,
+        type: TransactionType = .expense,
+        categoryID: String? = nil,
+        notes: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.price = price
+        self.date = date
+        self.category = category
+        self.type = type
+        self.categoryID = categoryID ?? category.categoryID
+        self.notes = notes
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case price
+        case date
+        case category
+        case type
+        case categoryID
+        case notes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        title = try container.decode(String.self, forKey: .title)
+        price = try container.decode(Double.self, forKey: .price)
+        date = try container.decode(Date.self, forKey: .date)
+        category = try container.decodeIfPresent(Category.self, forKey: .category) ?? .others
+        type = try container.decodeIfPresent(TransactionType.self, forKey: .type) ?? .expense
+        categoryID = try container.decodeIfPresent(String.self, forKey: .categoryID) ?? category.categoryID
+        notes = try container.decodeIfPresent(String.self, forKey: .notes)
+    }
 }

--- a/iExpense/Services/StorageService.swift
+++ b/iExpense/Services/StorageService.swift
@@ -16,6 +16,7 @@ struct StorageService {
 
     private static let expensesKey = "expenses"
     private static let budgetsKey = "budgets"
+    private static let customCategoriesKey = "customCategories"
 
     static func saveExpenses(_ expenses: [Expense]) {
         guard let userDefaults = userDefaults else { return }
@@ -35,7 +36,29 @@ struct StorageService {
         }
         do {
             let decoder = JSONDecoder()
-            let expenses = try decoder.decode([Expense].self, from: data)
+            var expenses = try decoder.decode([Expense].self, from: data)
+            var needsSave = false
+
+            for index in expenses.indices {
+                if expenses[index].categoryID.isEmpty {
+                    expenses[index].categoryID = expenses[index].category.categoryID
+                    needsSave = true
+                }
+
+                if expenses[index].notes == nil {
+                    let notesKey = "notes_\(expenses[index].id.uuidString)"
+                    if let legacyNotes = UserDefaults.standard.string(forKey: notesKey),
+                       !legacyNotes.isEmpty {
+                        expenses[index].notes = legacyNotes
+                        needsSave = true
+                    }
+                }
+            }
+
+            if needsSave {
+                saveExpenses(expenses)
+            }
+
             return expenses
         } catch {
             // Error handling without print
@@ -70,5 +93,28 @@ struct StorageService {
     static func clearExpenses() {
         guard let userDefaults = userDefaults else { return }
         userDefaults.removeObject(forKey: expensesKey)
+    }
+
+    static func saveCustomCategories(_ categories: [FinanceCategory]) {
+        guard let userDefaults = userDefaults else { return }
+        do {
+            let data = try JSONEncoder().encode(categories)
+            userDefaults.set(data, forKey: customCategoriesKey)
+        } catch {
+            // Error handling without print
+        }
+    }
+
+    static func loadCustomCategories() -> [FinanceCategory] {
+        guard let userDefaults = userDefaults,
+              let data = userDefaults.data(forKey: customCategoriesKey) else {
+            return []
+        }
+
+        do {
+            return try JSONDecoder().decode([FinanceCategory].self, from: data)
+        } catch {
+            return []
+        }
     }
 }

--- a/iExpense/Services/StorageService.swift
+++ b/iExpense/Services/StorageService.swift
@@ -16,6 +16,7 @@ struct StorageService {
 
     private static let expensesKey = "expenses"
     private static let budgetsKey = "budgets"
+    private static let categoryCatalogStateKey = "categoryCatalogState"
     private static let customCategoriesKey = "customCategories"
 
     static func saveExpenses(_ expenses: [Expense]) {
@@ -115,6 +116,29 @@ struct StorageService {
             return try JSONDecoder().decode([FinanceCategory].self, from: data)
         } catch {
             return []
+        }
+    }
+
+    static func saveCategoryCatalogState(_ state: CategoryCatalogState) {
+        guard let userDefaults = userDefaults else { return }
+        do {
+            let data = try JSONEncoder().encode(state)
+            userDefaults.set(data, forKey: categoryCatalogStateKey)
+        } catch {
+            // Error handling without print
+        }
+    }
+
+    static func loadCategoryCatalogState() -> CategoryCatalogState? {
+        guard let userDefaults = userDefaults,
+              let data = userDefaults.data(forKey: categoryCatalogStateKey) else {
+            return nil
+        }
+
+        do {
+            return try JSONDecoder().decode(CategoryCatalogState.self, from: data)
+        } catch {
+            return nil
         }
     }
 }

--- a/iExpense/ViewModels/AnalyticsViewModel.swift
+++ b/iExpense/ViewModels/AnalyticsViewModel.swift
@@ -401,6 +401,16 @@ class AnalyticsViewModel: ObservableObject {
     }
 
     private func categoryName(for categoryID: String) -> String {
+        if let catalogState = StorageService.loadCategoryCatalogState() {
+            let builtInCategories = FinanceCategory.builtInCategories.map { category in
+                catalogState.builtInOverrides[category.id] ?? category
+            }
+
+            if let category = (builtInCategories + catalogState.customCategories).first(where: { $0.id == categoryID }) {
+                return category.displayName
+            }
+        }
+
         if let builtInCategory = Category.category(from: categoryID) {
             return builtInCategory.displayName
         }

--- a/iExpense/ViewModels/AnalyticsViewModel.swift
+++ b/iExpense/ViewModels/AnalyticsViewModel.swift
@@ -2,20 +2,17 @@
 //  AnalyticsViewModel.swift
 //  iExpense
 //
-//  Created by Dragomir Mindrescu on 27.04.2025.
-//
 
 import Foundation
 import SwiftUI
 
-// Structure to hold insight about spending
 struct SpendingInsight {
     let type: InsightType
     let title: String
     let description: String
     let icon: String
     let color: Color
-    
+
     enum InsightType {
         case positive
         case neutral
@@ -23,12 +20,11 @@ struct SpendingInsight {
     }
 }
 
-// Structure to hold daily spending data
 struct DailySpending {
     let date: Date
     let amount: Double
     let dayOfMonth: Int
-    
+
     var weekday: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "EEE"
@@ -36,12 +32,11 @@ struct DailySpending {
     }
 }
 
-// Monthly trend data
 struct MonthlyTrend {
     let month: Int
     let year: Int
     let amount: Double
-    
+
     var monthName: String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MMM"
@@ -52,7 +47,7 @@ struct MonthlyTrend {
         guard let date = calendar.date(from: components) else { return "" }
         return dateFormatter.string(from: date)
     }
-    
+
     var shortMonthName: String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MMM"
@@ -65,43 +60,45 @@ struct MonthlyTrend {
     }
 }
 
-// Category spending trend data
 struct CategoryTrend {
-    let category: Category
+    let categoryID: String
     let previousAmount: Double
     let currentAmount: Double
-    
+
     var percentChange: Double {
         guard previousAmount > 0 else { return currentAmount > 0 ? 100 : 0 }
         return ((currentAmount - previousAmount) / previousAmount) * 100
     }
-    
+
     var isIncreasing: Bool {
-        return currentAmount > previousAmount
+        currentAmount > previousAmount
     }
 }
 
 @MainActor
 class AnalyticsViewModel: ObservableObject {
     @Published private(set) var totalSpent: Double = 0.0
-    @Published private(set) var spendingByCategory: [Category: Double] = [:]
+    @Published private(set) var totalIncome: Double = 0.0
+    @Published private(set) var netCashflow: Double = 0.0
+    @Published private(set) var spendingByCategory: [String: Double] = [:]
+    @Published private(set) var incomeByCategory: [String: Double] = [:]
     @Published private(set) var dailySpending: [DailySpending] = []
     @Published private(set) var monthlyTrends: [MonthlyTrend] = []
     @Published private(set) var categoryTrends: [CategoryTrend] = []
     @Published private(set) var insights: [SpendingInsight] = []
     @Published private(set) var averageDailySpend: Double = 0.0
     @Published private(set) var projectedMonthlySpend: Double = 0.0
-    @Published private(set) var biggestExpenseCategory: (Category, Double)? = nil
-    @Published private(set) var fastestGrowingCategory: (Category, Double)? = nil
-    
+    @Published private(set) var biggestExpenseCategory: (String, Double)? = nil
+    @Published private(set) var fastestGrowingCategory: (String, Double)? = nil
+
     @Published var selectedMonth: Int = Calendar.current.component(.month, from: Date())
     @Published var selectedYear: Int = Calendar.current.component(.year, from: Date())
-    
+
     @Published var monthlyBudgets: [String: Double] = [:]
     @Published var currentBudget: Double = 0.0
     @Published var budgetRemainingPerDay: Double = 0.0
     @Published var daysRemainingInMonth: Int = 0
-    
+
     private var expenses: [Expense] = []
 
     init(expenses: [Expense]) {
@@ -109,218 +106,185 @@ class AnalyticsViewModel: ObservableObject {
         self.monthlyBudgets = StorageService.loadBudgets()
         calculateAnalytics()
     }
-    
+
     func updateExpenses(_ expenses: [Expense]) {
         self.expenses = expenses
         calculateAnalytics()
     }
-    
+
     func calculateAnalytics() {
         let calendar = Calendar.current
-        
-        // Filter expenses for the current selected month/year
-        let filteredExpenses = expenses.filter { expense in
+
+        let filteredTransactions = expenses.filter { expense in
             let expenseMonth = calendar.component(.month, from: expense.date)
             let expenseYear = calendar.component(.year, from: expense.date)
             return expenseMonth == selectedMonth && expenseYear == selectedYear
         }
-        
-        // Calculate total spent in the selected month
+
+        let filteredExpenses = filteredTransactions.filter { $0.type == .expense }
+        let filteredIncomes = filteredTransactions.filter { $0.type == .income }
+
         totalSpent = filteredExpenses.reduce(0) { $0 + $1.price }
-        
-        // Calculate spending by category
-        var categoryTotals: [Category: Double] = [:]
-        for expense in filteredExpenses {
-            categoryTotals[expense.category, default: 0] += expense.price
-        }
-        spendingByCategory = categoryTotals
-        
-        // Get the biggest expense category
-        if let maxCategory = spendingByCategory.max(by: { $0.value < $1.value }) {
-            biggestExpenseCategory = maxCategory
-        } else {
-            biggestExpenseCategory = nil
-        }
-        
-        // Calculate daily spending pattern
+        totalIncome = filteredIncomes.reduce(0) { $0 + $1.price }
+        netCashflow = totalIncome - totalSpent
+
+        spendingByCategory = totalsByCategory(for: filteredExpenses)
+        incomeByCategory = totalsByCategory(for: filteredIncomes)
+        biggestExpenseCategory = spendingByCategory.max(by: { $0.value < $1.value })
+
         calculateDailySpending(filteredExpenses: filteredExpenses)
-        
-        // Calculate trends compared to previous months
         calculateMonthlyTrends()
-        
-        // Calculate category trends
         calculateCategoryTrends()
-        
-        // Calculate insights
-        generateInsights()
-        
-        // Budget calculations
+
         let key = budgetKey(forMonth: selectedMonth, year: selectedYear)
         currentBudget = monthlyBudgets[key] ?? 0.0
-        
-        // Calculate days remaining in month
         calculateDaysRemainingAndBudget()
+        generateInsights()
     }
-    
+
+    private func totalsByCategory(for transactions: [Expense]) -> [String: Double] {
+        var totals: [String: Double] = [:]
+        for transaction in transactions {
+            totals[transaction.categoryID, default: 0] += transaction.price
+        }
+        return totals
+    }
+
     private func calculateDailySpending(filteredExpenses: [Expense]) {
         let calendar = Calendar.current
-        
-        // Group expenses by day
+
         let groupedByDay = Dictionary(grouping: filteredExpenses) { expense in
             calendar.startOfDay(for: expense.date)
         }
-        
-        // Create daily spending data
+
         var dailyData: [DailySpending] = []
-        
-        // Get the start and end of the selected month
         var components = DateComponents()
         components.year = selectedYear
         components.month = selectedMonth
         components.day = 1
-        
-        guard let startOfMonth = calendar.date(from: components) else { return }
-        guard let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth) else { return }
-        
-        // Create array of all days in the month
+
+        guard let startOfMonth = calendar.date(from: components),
+              let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth) else {
+            return
+        }
+
         var currentDate = startOfMonth
         while currentDate <= endOfMonth {
             let dayOfMonth = calendar.component(.day, from: currentDate)
             let amount = groupedByDay[calendar.startOfDay(for: currentDate)]?.reduce(0) { $0 + $1.price } ?? 0
-            
-            dailyData.append(DailySpending(
-                date: currentDate,
-                amount: amount,
-                dayOfMonth: dayOfMonth
-            ))
-            
+
+            dailyData.append(DailySpending(date: currentDate, amount: amount, dayOfMonth: dayOfMonth))
+
             guard let nextDay = calendar.date(byAdding: .day, value: 1, to: currentDate) else { break }
             currentDate = nextDay
         }
-        
+
         dailySpending = dailyData
-        
-        // Calculate average daily spend for days with expenses
+
         let daysWithExpenses = dailyData.filter { $0.amount > 0 }
         if !daysWithExpenses.isEmpty {
             averageDailySpend = daysWithExpenses.reduce(0) { $0 + $1.amount } / Double(daysWithExpenses.count)
         } else {
             averageDailySpend = 0
         }
-        
-        // Calculate projected monthly spend based on daily average
+
         if averageDailySpend > 0 {
-            let totalDaysInMonth = dailyData.count
-            projectedMonthlySpend = averageDailySpend * Double(totalDaysInMonth)
+            projectedMonthlySpend = averageDailySpend * Double(dailyData.count)
         } else {
             projectedMonthlySpend = totalSpent
         }
     }
-    
+
     private func calculateMonthlyTrends() {
         var trends: [MonthlyTrend] = []
         let calendar = Calendar.current
-        
-        // Calculate 6 months of data (including current)
-        for i in 0..<6 {
-            guard let date = calendar.date(byAdding: .month, value: -i, to: Date()) else { continue }
-            
+
+        for index in 0..<6 {
+            guard let date = calendar.date(byAdding: .month, value: -index, to: Date()) else { continue }
+
             let month = calendar.component(.month, from: date)
             let year = calendar.component(.year, from: date)
-            
-            let monthlyExpenses = expenses.filter { expense in
-                let expenseMonth = calendar.component(.month, from: expense.date)
-                let expenseYear = calendar.component(.year, from: expense.date)
-                return expenseMonth == month && expenseYear == year
-            }
-            
-            let totalAmount = monthlyExpenses.reduce(0) { $0 + $1.price }
+
+            let totalAmount = expenses
+                .filter { expense in
+                    let expenseMonth = calendar.component(.month, from: expense.date)
+                    let expenseYear = calendar.component(.year, from: expense.date)
+                    return expense.type == .expense && expenseMonth == month && expenseYear == year
+                }
+                .reduce(0) { $0 + $1.price }
+
             trends.append(MonthlyTrend(month: month, year: year, amount: totalAmount))
         }
-        
-        // Sort by date (oldest first)
-        monthlyTrends = trends.sorted(by: { 
+
+        monthlyTrends = trends.sorted {
             if $0.year != $1.year {
                 return $0.year < $1.year
             }
             return $0.month < $1.month
-        })
+        }
     }
-    
+
     private func calculateCategoryTrends() {
-        var trends: [CategoryTrend] = []
         let calendar = Calendar.current
-        
-        // Get current month data
+
         let currentMonthExpenses = expenses.filter { expense in
             let expenseMonth = calendar.component(.month, from: expense.date)
             let expenseYear = calendar.component(.year, from: expense.date)
-            return expenseMonth == selectedMonth && expenseYear == selectedYear
+            return expense.type == .expense && expenseMonth == selectedMonth && expenseYear == selectedYear
         }
-        
-        // Get previous month
+
         var previousMonthComponents = DateComponents()
         previousMonthComponents.month = selectedMonth
         previousMonthComponents.year = selectedYear
-        
+
         guard let currentDate = calendar.date(from: previousMonthComponents),
-              let previousMonthDate = calendar.date(byAdding: .month, value: -1, to: currentDate) else { return }
-        
+              let previousMonthDate = calendar.date(byAdding: .month, value: -1, to: currentDate) else {
+            categoryTrends = []
+            fastestGrowingCategory = nil
+            return
+        }
+
         let previousMonth = calendar.component(.month, from: previousMonthDate)
         let previousYear = calendar.component(.year, from: previousMonthDate)
-        
-        // Get previous month data
+
         let previousMonthExpenses = expenses.filter { expense in
             let expenseMonth = calendar.component(.month, from: expense.date)
             let expenseYear = calendar.component(.year, from: expense.date)
-            return expenseMonth == previousMonth && expenseYear == previousYear
+            return expense.type == .expense && expenseMonth == previousMonth && expenseYear == previousYear
         }
-        
-        // Calculate current month category totals
-        var currentCategoryTotals: [Category: Double] = [:]
-        for expense in currentMonthExpenses {
-            currentCategoryTotals[expense.category, default: 0] += expense.price
+
+        let currentCategoryTotals = totalsByCategory(for: currentMonthExpenses)
+        let previousCategoryTotals = totalsByCategory(for: previousMonthExpenses)
+        let categoryIDs = Set(currentCategoryTotals.keys).union(previousCategoryTotals.keys)
+
+        let trends = categoryIDs.compactMap { categoryID -> CategoryTrend? in
+            let currentAmount = currentCategoryTotals[categoryID] ?? 0
+            let previousAmount = previousCategoryTotals[categoryID] ?? 0
+
+            guard currentAmount > 0 || previousAmount > 0 else { return nil }
+            return CategoryTrend(
+                categoryID: categoryID,
+                previousAmount: previousAmount,
+                currentAmount: currentAmount
+            )
         }
-        
-        // Calculate previous month category totals
-        var previousCategoryTotals: [Category: Double] = [:]
-        for expense in previousMonthExpenses {
-            previousCategoryTotals[expense.category, default: 0] += expense.price
-        }
-        
-        // Create trend data for each category
-        for category in Category.allCases {
-            let currentAmount = currentCategoryTotals[category] ?? 0
-            let previousAmount = previousCategoryTotals[category] ?? 0
-            
-            // Only add if there was spending in either month
-            if currentAmount > 0 || previousAmount > 0 {
-                trends.append(CategoryTrend(
-                    category: category,
-                    previousAmount: previousAmount,
-                    currentAmount: currentAmount
-                ))
-            }
-        }
-        
+
         categoryTrends = trends
-        
-        // Find fastest growing category (if any has previous data)
+
         let growingCategories = trends.filter { $0.previousAmount > 0 && $0.currentAmount > $0.previousAmount }
         if let fastestGrowing = growingCategories.max(by: { $0.percentChange < $1.percentChange }) {
-            fastestGrowingCategory = (fastestGrowing.category, fastestGrowing.percentChange)
+            fastestGrowingCategory = (fastestGrowing.categoryID, fastestGrowing.percentChange)
         } else {
             fastestGrowingCategory = nil
         }
     }
-    
+
     private func generateInsights() {
         var newInsights: [SpendingInsight] = []
-        
-        // Budget insight
+
         if currentBudget > 0 {
             let percentOfBudgetUsed = (totalSpent / currentBudget) * 100
-            
+
             if percentOfBudgetUsed >= 90 {
                 newInsights.append(SpendingInsight(
                     type: .negative,
@@ -347,43 +311,40 @@ class AnalyticsViewModel: ObservableObject {
                 ))
             }
         }
-        
-        // Category trend insights
+
         if let fastestGrowing = fastestGrowingCategory, fastestGrowing.1 > 30 {
             newInsights.append(SpendingInsight(
                 type: .negative,
                 title: "Spending Increase",
-                description: "\(fastestGrowing.0.displayName) spending increased by \(Int(fastestGrowing.1))% from last month.",
+                description: "\(categoryName(for: fastestGrowing.0)) spending increased by \(Int(fastestGrowing.1))% from last month.",
                 icon: "arrow.up.right",
                 color: .red
             ))
         }
-        
-        // Reduction in spending
-        let reducedCategories = categoryTrends.filter { 
-            $0.previousAmount > 0 && 
-            $0.currentAmount < $0.previousAmount && 
+
+        let reducedCategories = categoryTrends.filter {
+            $0.previousAmount > 0 &&
+            $0.currentAmount < $0.previousAmount &&
             abs($0.percentChange) > 20
         }
-        
+
         if let bestReduction = reducedCategories.min(by: { $0.percentChange < $1.percentChange }) {
             newInsights.append(SpendingInsight(
                 type: .positive,
                 title: "Spending Decrease",
-                description: "You reduced \(bestReduction.category.displayName) spending by \(Int(abs(bestReduction.percentChange)))%.",
+                description: "You reduced \(categoryName(for: bestReduction.categoryID)) spending by \(Int(abs(bestReduction.percentChange)))%.",
                 icon: "arrow.down.right",
                 color: .green
             ))
         }
-        
-        // Projected spending insight
+
         if projectedMonthlySpend > currentBudget && currentBudget > 0 {
             let projectedOverage = projectedMonthlySpend - currentBudget
             let formatter = NumberFormatter()
             formatter.numberStyle = .currency
             formatter.currencyCode = SettingsViewModel.getAppCurrency()
             let formattedOverage = formatter.string(from: NSNumber(value: projectedOverage)) ?? String(projectedOverage)
-            
+
             newInsights.append(SpendingInsight(
                 type: .negative,
                 title: "Projected Overspending",
@@ -392,59 +353,60 @@ class AnalyticsViewModel: ObservableObject {
                 color: .red
             ))
         }
-        
+
         insights = newInsights
     }
-    
+
     private func calculateDaysRemainingAndBudget() {
         let calendar = Calendar.current
-        
-        // Create date components for the current month
+
         var components = DateComponents()
         components.year = selectedYear
         components.month = selectedMonth
         components.day = 1
-        
-        // Get today's date
+
         let today = calendar.startOfDay(for: Date())
-        
-        // Get start of the selected month
-        guard let startOfMonth = calendar.date(from: components) else { return }
-        
-        // Get end of the selected month
-        guard let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth) else { return }
-        
-        // If we're viewing a past month, days remaining is 0
+
+        guard let startOfMonth = calendar.date(from: components),
+              let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth) else {
+            return
+        }
+
         if endOfMonth < today {
             daysRemainingInMonth = 0
             budgetRemainingPerDay = 0
             return
         }
-        
-        // If we're viewing a future month, days remaining is the full month
+
         if startOfMonth > today {
             daysRemainingInMonth = calendar.component(.day, from: endOfMonth)
             budgetRemainingPerDay = currentBudget / Double(daysRemainingInMonth)
             return
         }
-        
-        // Calculate days remaining in the current month
+
         daysRemainingInMonth = calendar.dateComponents([.day], from: today, to: endOfMonth).day ?? 0
-        
-        // Calculate remaining budget
+
         let remainingBudget = max(0, currentBudget - totalSpent)
-        
-        // Calculate budget per day for the remainder of the month
         budgetRemainingPerDay = daysRemainingInMonth > 0 ? remainingBudget / Double(daysRemainingInMonth) : 0
     }
-    
+
     func changeMonthYear(month: Int, year: Int) {
         selectedMonth = month
         selectedYear = year
         calculateAnalytics()
     }
-    
+
     func budgetKey(forMonth month: Int, year: Int) -> String {
         String(format: "%02d-%d", month, year)
+    }
+
+    private func categoryName(for categoryID: String) -> String {
+        if let builtInCategory = Category.category(from: categoryID) {
+            return builtInCategory.displayName
+        }
+
+        return StorageService.loadCustomCategories()
+            .first { $0.id == categoryID }?
+            .displayName ?? FinanceCategory.fallback.displayName
     }
 }

--- a/iExpense/ViewModels/ExpenseViewModel.swift
+++ b/iExpense/ViewModels/ExpenseViewModel.swift
@@ -16,8 +16,24 @@ class ExpenseViewModel: ObservableObject {
         loadExpenses()
     }
     
-    func addExpense(title: String, price: Double, date: Date, category: Category) -> Expense {
-        let newExpense = Expense(title: title, price: price, date: date, category: category)
+    func addExpense(
+        title: String,
+        price: Double,
+        date: Date,
+        category: Category,
+        type: TransactionType = .expense,
+        categoryID: String? = nil,
+        notes: String? = nil
+    ) -> Expense {
+        let newExpense = Expense(
+            title: title,
+            price: price,
+            date: date,
+            category: category,
+            type: type,
+            categoryID: categoryID,
+            notes: notes
+        )
         expenses.append(newExpense)
         saveExpenses()
         return newExpense

--- a/iExpense/ViewModels/SettingsViewModel.swift
+++ b/iExpense/ViewModels/SettingsViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import WidgetKit
 
 enum AppTheme: String, CaseIterable, Identifiable {
     case light, dark, system
@@ -47,7 +48,7 @@ let availableCurrencies: [(code: String, symbol: String, name: String)] = [
 
 @MainActor
 class SettingsViewModel: ObservableObject {
-    @Published var selectedCurrency: String {
+    @Published var selectedCurrency: String = "USD" {
         didSet {
             // Save to standard UserDefaults
             UserDefaults.standard.set(selectedCurrency, forKey: "selectedCurrency")
@@ -56,16 +57,27 @@ class SettingsViewModel: ObservableObject {
             let sharedDefaults = UserDefaults(suiteName: StorageService.appGroupID)
             sharedDefaults?.set(selectedCurrency, forKey: "selectedCurrency")
             sharedDefaults?.synchronize() // Force immediate write
+            WidgetCenter.shared.reloadAllTimelines()
         }
     }
     
-    @Published var defaultCategory: Category {
+    @Published var defaultCategory: Category = .food {
         didSet {
             UserDefaults.standard.set(defaultCategory.rawValue, forKey: "defaultCategory")
         }
     }
+
+    @Published var defaultCategoryID: String = Category.food.categoryID {
+        didSet {
+            UserDefaults.standard.set(defaultCategoryID, forKey: "defaultCategoryID")
+
+            if let builtInCategory = Category.category(from: defaultCategoryID) {
+                defaultCategory = builtInCategory
+            }
+        }
+    }
     
-    @Published var selectedTheme: AppTheme {
+    @Published var selectedTheme: AppTheme = .system {
         didSet {
             UserDefaults.standard.set(selectedTheme.rawValue, forKey: "selectedTheme")
         }
@@ -97,6 +109,7 @@ class SettingsViewModel: ObservableObject {
         
         let savedCategory = UserDefaults.standard.string(forKey: "defaultCategory")
         self.defaultCategory = Category(rawValue: savedCategory ?? "food") ?? .food
+        self.defaultCategoryID = UserDefaults.standard.string(forKey: "defaultCategoryID") ?? self.defaultCategory.categoryID
         
         let savedTheme = UserDefaults.standard.string(forKey: "selectedTheme")
         self.selectedTheme = AppTheme(rawValue: savedTheme ?? "system") ?? .system

--- a/iExpense/Views/AddExpenseView.swift
+++ b/iExpense/Views/AddExpenseView.swift
@@ -238,7 +238,7 @@ struct AddExpenseView: View {
                 Text("Transaction Added!")
                     .font(.title2)
                     .fontWeight(.bold)
-                    .foregroundColor(.black)
+                    .foregroundColor(.primary)
             }
             .padding(30)
             .background(

--- a/iExpense/Views/AddExpenseView.swift
+++ b/iExpense/Views/AddExpenseView.swift
@@ -10,19 +10,20 @@ import SwiftUI
 struct AddExpenseView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.colorScheme) var colorScheme
+    @EnvironmentObject private var settingsViewModel: SettingsViewModel
+    @EnvironmentObject private var categoryStore: CategoryStore
     @ObservedObject var viewModel: ExpenseViewModel
-    @StateObject private var settingsViewModel = SettingsViewModel()
     
     // Form fields
     @State private var title: String = ""
     @State private var price: String = ""
-    @State private var selectedCategory: Category
+    @State private var selectedCategoryID: String
+    @State private var transactionType: TransactionType = .expense
     @State private var selectedDate: Date = Date()
     @State private var notes: String = ""
     
     // UI States
     @State private var showDatePicker = false
-    @State private var keyboardHeight: CGFloat = 0
     @State private var keyboardVisible: Bool = false
     @State private var showingValidationAlert = false
     @State private var validationMessage = ""
@@ -31,15 +32,15 @@ struct AddExpenseView: View {
     // Current currency symbol
     private var currencySymbol: String {
         let locale = Locale.current
-        let currencyCode = SettingsViewModel.getAppCurrency()
+        let currencyCode = settingsViewModel.selectedCurrency
         return locale.localizedCurrencySymbol(forCurrencyCode: currencyCode) ?? currencyCode
     }
     
     init(viewModel: ExpenseViewModel) {
         self.viewModel = viewModel
         // Initialize with the default category from settings
-        let defaultCategory = UserDefaults.standard.string(forKey: "defaultCategory") ?? Category.food.rawValue
-        _selectedCategory = State(initialValue: Category(rawValue: defaultCategory) ?? .food)
+        let defaultCategoryID = UserDefaults.standard.string(forKey: "defaultCategoryID") ?? Category.food.categoryID
+        _selectedCategoryID = State(initialValue: defaultCategoryID)
     }
     
     var body: some View {
@@ -55,7 +56,10 @@ struct AddExpenseView: View {
                         
                         // Category selection
                         CardView(title: "Category") {
-                            CategoryGrid(selectedCategory: $selectedCategory)
+                            CategoryGrid(
+                                selectedCategoryID: $selectedCategoryID,
+                                categories: categoryStore.allCategories
+                            )
                                 .padding(.horizontal)
                         }
                         
@@ -81,15 +85,16 @@ struct AddExpenseView: View {
                     }
                     .padding(.horizontal)
                     .padding(.top, 10)
-                    .padding(.bottom, keyboardHeight > 0 ? keyboardHeight - 40 : 20)
+                    .padding(.bottom, 24)
                 }
+                .scrollDismissesKeyboard(.interactively)
                 
                 // Success animation overlay
                 if animateSuccess {
                     successOverlay
                 }
             }
-            .navigationTitle("Add Expense")
+            .navigationTitle("Add Transaction")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -107,11 +112,15 @@ struct AddExpenseView: View {
                     }
                 }
             }
-            .onAppear {
-                setupKeyboardObservers()
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+                withAnimation {
+                    keyboardVisible = true
+                }
             }
-            .onDisappear {
-                removeKeyboardObservers()
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+                withAnimation {
+                    keyboardVisible = false
+                }
             }
             .alert(validationMessage, isPresented: $showingValidationAlert) {
                 Button("OK", role: .cancel) { }
@@ -122,13 +131,21 @@ struct AddExpenseView: View {
     // MARK: - Main Data Card
     
     private var mainDataCard: some View {
-        CardView(title: "Expense Details", showDivider: true) {
+        CardView(title: "Transaction Details", showDivider: true) {
             VStack(spacing: 16) {
+                Picker("Type", selection: $transactionType) {
+                    ForEach(TransactionType.allCases) { type in
+                        Text(type.displayName).tag(type)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+
                 // Title field
                 TextFormField(
                     label: "Title",
                     text: $title,
-                    placeholder: "Expense title",
+                    placeholder: transactionType == .expense ? "Expense title" : "Income title",
                     leadingIcon: "pencil"
                 )
                 .padding(.horizontal)
@@ -175,7 +192,7 @@ struct AddExpenseView: View {
         Button(action: saveExpense) {
             HStack {
                 Spacer()
-                Text("Save Expense")
+                Text("Save Transaction")
                 Spacer()
             }
             .padding()
@@ -218,10 +235,10 @@ struct AddExpenseView: View {
                     .font(.system(size: 80))
                     .foregroundColor(.green)
                 
-                Text("Expense Added!")
+                Text("Transaction Added!")
                     .font(.title2)
                     .fontWeight(.bold)
-                    .foregroundColor(.white)
+                    .foregroundColor(.black)
             }
             .padding(30)
             .background(
@@ -247,12 +264,12 @@ struct AddExpenseView: View {
         
         // Validate inputs
         if title.isEmpty {
-            showValidationAlert("Please enter a title for your expense.")
+            showValidationAlert("Please enter a title.")
             return
         }
         
         if price.isEmpty {
-            showValidationAlert("Please enter the expense amount.")
+            showValidationAlert("Please enter an amount.")
             return
         }
         
@@ -267,22 +284,20 @@ struct AddExpenseView: View {
             animateSuccess = true
         }
         
-        // Add the expense with all fields
-        let newExpense = viewModel.addExpense(
+        let selectedCategory = categoryStore.category(for: selectedCategoryID)
+        let legacyCategory = Category.category(from: selectedCategory.id) ?? .others
+        let trimmedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Add the transaction with all fields
+        _ = viewModel.addExpense(
             title: title,
             price: priceValue,
             date: selectedDate,
-            category: selectedCategory
+            category: legacyCategory,
+            type: transactionType,
+            categoryID: selectedCategory.id,
+            notes: trimmedNotes.isEmpty ? nil : trimmedNotes
         )
-        
-        // Save notes to UserDefaults using the expense ID
-        if !notes.isEmpty {
-            let notesKey = "notes_\(newExpense.id.uuidString)"
-            print("DEBUG: Saving notes for new expense: \(newExpense.id.uuidString)")
-            print("DEBUG: Notes content: \"\(notes)\"")
-            UserDefaults.standard.set(notes, forKey: notesKey)
-            UserDefaults.standard.synchronize()
-        }
         
         // Trigger success haptic
         HapticFeedback.success()
@@ -302,29 +317,6 @@ struct AddExpenseView: View {
     private func hideKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
-    
-    private func setupKeyboardObservers() {
-        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { notification in
-            if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
-                self.keyboardHeight = keyboardFrame.height
-                withAnimation {
-                    self.keyboardVisible = true
-                }
-            }
-        }
-        
-        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
-            self.keyboardHeight = 0
-            withAnimation {
-                self.keyboardVisible = false
-            }
-        }
-    }
-    
-    private func removeKeyboardObservers() {
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
 }
 
 // MARK: - Locale Extension
@@ -338,4 +330,6 @@ extension Locale {
 
 #Preview {
     AddExpenseView(viewModel: ExpenseViewModel())
+        .environmentObject(SettingsViewModel())
+        .environmentObject(CategoryStore())
 }

--- a/iExpense/Views/AddExpenseView.swift
+++ b/iExpense/Views/AddExpenseView.swift
@@ -125,6 +125,9 @@ struct AddExpenseView: View {
             .alert(validationMessage, isPresented: $showingValidationAlert) {
                 Button("OK", role: .cancel) { }
             }
+            .onAppear {
+                selectedCategoryID = categoryStore.preferredCategoryID(for: selectedCategoryID)
+            }
         }
     }
     

--- a/iExpense/Views/AnalyticsView.swift
+++ b/iExpense/Views/AnalyticsView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 import Charts
 
 struct AnalyticsView: View {
+    @EnvironmentObject private var settingsViewModel: SettingsViewModel
+
     @ObservedObject var analyticsViewModel: AnalyticsViewModel
     @State private var selectedTab: AnalyticsTab = .overview
     @State private var showSaveBudgetSuccess: Bool = false
@@ -22,6 +24,10 @@ struct AnalyticsView: View {
         // Initialize the state variables with the view model values
         _selectedMonth = State(initialValue: analyticsViewModel.selectedMonth)
         _selectedYear = State(initialValue: analyticsViewModel.selectedYear)
+    }
+
+    private var currencyCode: String {
+        settingsViewModel.selectedCurrency
     }
     
     var body: some View {
@@ -95,7 +101,8 @@ struct AnalyticsView: View {
             // Category Spending Breakdown
             CategoryBreakdownView(
                 spendingByCategory: analyticsViewModel.spendingByCategory,
-                totalSpent: analyticsViewModel.totalSpent
+                totalSpent: analyticsViewModel.totalSpent,
+                currencyCode: currencyCode
             )
         }
     }
@@ -108,7 +115,26 @@ struct AnalyticsView: View {
                 value: analyticsViewModel.totalSpent,
                 valueFormat: .currency,
                 icon: "dollarsign.circle.fill",
-                color: .blue
+                color: .blue,
+                currencyCode: currencyCode
+            ),
+
+            SummaryCard(
+                title: "Income",
+                value: analyticsViewModel.totalIncome,
+                valueFormat: .currency,
+                icon: "arrow.down.circle.fill",
+                color: .green,
+                currencyCode: currencyCode
+            ),
+
+            SummaryCard(
+                title: "Net",
+                value: analyticsViewModel.netCashflow,
+                valueFormat: .currency,
+                icon: "equal.circle.fill",
+                color: analyticsViewModel.netCashflow >= 0 ? .green : .red,
+                currencyCode: currencyCode
             ),
 
             // Daily Average
@@ -117,7 +143,8 @@ struct AnalyticsView: View {
                 value: analyticsViewModel.averageDailySpend,
                 valueFormat: .currency,
                 icon: "calendar.badge.clock",
-                color: .green
+                color: .green,
+                currencyCode: currencyCode
             ),
 
             // Budget Used or No Budget
@@ -128,14 +155,16 @@ struct AnalyticsView: View {
                     valueFormat: .percent,
                     icon: "chart.pie.fill",
                     color: min(100, (analyticsViewModel.totalSpent / analyticsViewModel.currentBudget) * 100) >= 90 ? .red : 
-                          (min(100, (analyticsViewModel.totalSpent / analyticsViewModel.currentBudget) * 100) >= 75 ? .orange : .blue)
+                          (min(100, (analyticsViewModel.totalSpent / analyticsViewModel.currentBudget) * 100) >= 75 ? .orange : .blue),
+                    currencyCode: currencyCode
                 ) :
                 SummaryCard(
                     title: "Budget",
                     value: 0,
                     valueFormat: .noBudget,
                     icon: "chart.pie.fill",
-                    color: .gray
+                    color: .gray,
+                    currencyCode: currencyCode
                 ),
 
             // Remaining Per Day or Days Left
@@ -145,14 +174,16 @@ struct AnalyticsView: View {
                     value: analyticsViewModel.budgetRemainingPerDay,
                     valueFormat: .currency,
                     icon: "calendar.badge.clock",
-                    color: .purple
+                    color: .purple,
+                    currencyCode: currencyCode
                 ) :
                 SummaryCard(
                     title: "Days Left",
                     value: Double(analyticsViewModel.daysRemainingInMonth),
                     valueFormat: .days,
                     icon: "calendar",
-                    color: .purple
+                    color: .purple,
+                    currencyCode: currencyCode
                 )
         ])
     }
@@ -169,19 +200,20 @@ struct AnalyticsView: View {
             // Top Growing Categories
             CategoryTrendsView(categoryTrends: analyticsViewModel.categoryTrends.map { trend in
                 CategoryTrendsView.CategoryTrend(
-                    category: trend.category,
+                    categoryID: trend.categoryID,
                     month: analyticsViewModel.selectedMonth,
                     year: analyticsViewModel.selectedYear,
                     currentAmount: trend.currentAmount,
                     previousAmount: trend.previousAmount
                 )
-            })
+            }, currencyCode: currencyCode)
             
             // Monthly Projection
             if analyticsViewModel.projectedMonthlySpend > 0 {
                 ProjectionView(
                     projectedMonthlySpend: analyticsViewModel.projectedMonthlySpend,
-                    currentBudget: analyticsViewModel.currentBudget
+                    currentBudget: analyticsViewModel.currentBudget,
+                    currencyCode: currencyCode
                 )
             }
         }
@@ -195,7 +227,8 @@ struct AnalyticsView: View {
             KeyStatisticsView(
                 biggestExpenseCategory: analyticsViewModel.biggestExpenseCategory,
                 totalSpent: analyticsViewModel.totalSpent,
-                mostActiveSpendingPeriod: findMostActiveSpendingPeriod()
+                mostActiveSpendingPeriod: findMostActiveSpendingPeriod(),
+                currencyCode: currencyCode
             )
             
             // Auto-generated insights
@@ -365,6 +398,7 @@ struct AnalyticsView: View {
             // Budget Input
             BudgetInputView(
                 currentBudget: $analyticsViewModel.currentBudget,
+                currencyCode: currencyCode,
                 onSave: saveBudget
             )
             
@@ -374,7 +408,8 @@ struct AnalyticsView: View {
                     totalSpent: analyticsViewModel.totalSpent,
                     currentBudget: analyticsViewModel.currentBudget,
                     daysRemainingInMonth: analyticsViewModel.daysRemainingInMonth,
-                    budgetRemainingPerDay: analyticsViewModel.budgetRemainingPerDay
+                    budgetRemainingPerDay: analyticsViewModel.budgetRemainingPerDay,
+                    currencyCode: currencyCode
                 )
                 
                 // Budget recommendations
@@ -383,7 +418,8 @@ struct AnalyticsView: View {
                     totalSpent: analyticsViewModel.totalSpent,
                     currentBudget: analyticsViewModel.currentBudget,
                     daysRemainingInMonth: analyticsViewModel.daysRemainingInMonth,
-                    suggestedBudget: calculateSuggestedBudget()
+                    suggestedBudget: calculateSuggestedBudget(),
+                    currencyCode: currencyCode
                 )
             }
             
@@ -446,4 +482,6 @@ struct AnalyticsView: View {
 
 #Preview {
     AnalyticsView(analyticsViewModel: AnalyticsViewModel(expenses: []))
+        .environmentObject(SettingsViewModel())
+        .environmentObject(CategoryStore())
 }

--- a/iExpense/Views/CategoryManagementView.swift
+++ b/iExpense/Views/CategoryManagementView.swift
@@ -1,0 +1,211 @@
+//
+//  CategoryManagementView.swift
+//  iExpense
+//
+
+import SwiftUI
+
+struct CategoryManagementView: View {
+    @EnvironmentObject private var categoryStore: CategoryStore
+    @State private var categoryToEdit: FinanceCategory?
+    @State private var showingEditor = false
+
+    var body: some View {
+        List {
+            Section("Built In") {
+                ForEach(FinanceCategory.builtInCategories) { category in
+                    categoryRow(category)
+                }
+            }
+
+            Section("Custom") {
+                if categoryStore.customCategories.isEmpty {
+                    Text("No custom categories yet")
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(categoryStore.customCategories) { category in
+                        categoryRow(category)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                categoryToEdit = category
+                                showingEditor = true
+                            }
+                            .swipeActions {
+                                Button(role: .destructive) {
+                                    categoryStore.deleteCategory(category)
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Categories")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    categoryToEdit = nil
+                    showingEditor = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showingEditor) {
+            CategoryEditorView(category: categoryToEdit)
+                .environmentObject(categoryStore)
+        }
+    }
+
+    private func categoryRow(_ category: FinanceCategory) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: category.iconName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: 32, height: 32)
+                .background(category.color)
+                .clipShape(Circle())
+
+            Text(category.displayName)
+
+            Spacer()
+
+            if category.isCustom {
+                Image(systemName: "pencil")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+private struct CategoryEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var categoryStore: CategoryStore
+
+    let category: FinanceCategory?
+
+    @State private var name: String
+    @State private var iconName: String
+    @State private var colorHex: String
+    @State private var showingValidation = false
+
+    private let icons = [
+        "tag.fill", "briefcase.fill", "banknote.fill", "creditcard.fill",
+        "gift.fill", "cart.fill", "fork.knife", "house.fill",
+        "car.fill", "tram.fill", "airplane", "heart.fill",
+        "cross.case.fill", "book.fill", "graduationcap.fill", "gamecontroller.fill",
+        "music.note", "pawprint.fill", "leaf.fill", "hammer.fill"
+    ]
+
+    private let colors = [
+        "#007AFF", "#34C759", "#FF9500", "#FF3B30",
+        "#AF52DE", "#FF2D55", "#5856D6", "#00C7BE",
+        "#30B0C7", "#FFCC00", "#8E8E93", "#A2845E"
+    ]
+
+    init(category: FinanceCategory?) {
+        self.category = category
+        _name = State(initialValue: category?.name ?? "")
+        _iconName = State(initialValue: category?.iconName ?? "tag.fill")
+        _colorHex = State(initialValue: category?.colorHex ?? "#007AFF")
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Details") {
+                    TextField("Name", text: $name)
+                }
+
+                Section("Icon") {
+                    LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 5), spacing: 12) {
+                        ForEach(icons, id: \.self) { icon in
+                            Button {
+                                iconName = icon
+                            } label: {
+                                Image(systemName: icon)
+                                    .font(.system(size: 20, weight: .semibold))
+                                    .foregroundColor(iconName == icon ? .white : .primary)
+                                    .frame(width: 44, height: 44)
+                                    .background(iconName == icon ? Color.accentColor : Color(.tertiarySystemBackground))
+                                    .clipShape(Circle())
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.vertical, 6)
+                }
+
+                Section("Color") {
+                    LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 6), spacing: 12) {
+                        ForEach(colors, id: \.self) { color in
+                            Button {
+                                colorHex = color
+                            } label: {
+                                Circle()
+                                    .fill(Color(hex: color) ?? .gray)
+                                    .frame(width: 36, height: 36)
+                                    .overlay {
+                                        if colorHex == color {
+                                            Image(systemName: "checkmark")
+                                                .font(.caption.weight(.bold))
+                                                .foregroundColor(.white)
+                                        }
+                                    }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.vertical, 6)
+                }
+            }
+            .navigationTitle(category == nil ? "New Category" : "Edit Category")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") {
+                        save()
+                    }
+                }
+            }
+            .alert("Category name is required", isPresented: $showingValidation) {
+                Button("OK", role: .cancel) { }
+            }
+        }
+    }
+
+    private func save() {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            showingValidation = true
+            return
+        }
+
+        if var category {
+            category.name = trimmedName
+            category.iconName = iconName
+            category.colorHex = colorHex
+            categoryStore.updateCategory(category)
+        } else {
+            categoryStore.addCategory(name: trimmedName, iconName: iconName, colorHex: colorHex)
+        }
+
+        dismiss()
+    }
+}
+
+#Preview {
+    NavigationView {
+        CategoryManagementView()
+            .environmentObject(CategoryStore())
+    }
+}
+

--- a/iExpense/Views/CategoryManagementView.swift
+++ b/iExpense/Views/CategoryManagementView.swift
@@ -4,43 +4,30 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct CategoryManagementView: View {
     @EnvironmentObject private var categoryStore: CategoryStore
+    @EnvironmentObject private var settingsViewModel: SettingsViewModel
     @State private var categoryToEdit: FinanceCategory?
     @State private var showingEditor = false
+    @State private var targetedCategoryID: String?
+    @State private var draggedCategoryID: String?
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 12), count: 3)
 
     var body: some View {
-        List {
-            Section("Built In") {
-                ForEach(FinanceCategory.builtInCategories) { category in
-                    categoryRow(category)
-                }
-            }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                categorySection(title: "Visible", categories: categoryStore.visibleCategories, isHiddenSection: false)
 
-            Section("Custom") {
-                if categoryStore.customCategories.isEmpty {
-                    Text("No custom categories yet")
-                        .foregroundColor(.secondary)
-                } else {
-                    ForEach(categoryStore.customCategories) { category in
-                        categoryRow(category)
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                categoryToEdit = category
-                                showingEditor = true
-                            }
-                            .swipeActions {
-                                Button(role: .destructive) {
-                                    categoryStore.deleteCategory(category)
-                                } label: {
-                                    Label("Delete", systemImage: "trash")
-                                }
-                            }
-                    }
+                if !categoryStore.hiddenCategories.isEmpty {
+                    categorySection(title: "Hidden", categories: categoryStore.hiddenCategories, isHiddenSection: true)
                 }
             }
+            .padding()
         }
+        .background(Color(.systemGroupedBackground).ignoresSafeArea())
         .navigationTitle("Categories")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -55,34 +42,107 @@ struct CategoryManagementView: View {
         .sheet(isPresented: $showingEditor) {
             CategoryEditorView(category: categoryToEdit)
                 .environmentObject(categoryStore)
+                .environmentObject(settingsViewModel)
         }
     }
 
-    private func categoryRow(_ category: FinanceCategory) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: category.iconName)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(.white)
-                .frame(width: 32, height: 32)
-                .background(category.color)
-                .clipShape(Circle())
+    private func categorySection(title: String, categories: [FinanceCategory], isHiddenSection: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
 
-            Text(category.displayName)
-
-            Spacer()
-
-            if category.isCustom {
-                Image(systemName: "pencil")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(categories) { category in
+                    if isHiddenSection {
+                        managementTile(for: category, isHiddenSection: true)
+                    } else {
+                        managementTile(for: category, isHiddenSection: false)
+                            .onDrag {
+                                draggedCategoryID = category.id
+                                return NSItemProvider(object: category.id as NSString)
+                            } preview: {
+                                CategoryDragPreview(category: category)
+                            }
+                            .onDrop(
+                                of: [UTType.text],
+                                delegate: CategoryReorderDropDelegate(
+                                    destinationCategoryID: category.id,
+                                    draggedCategoryID: $draggedCategoryID,
+                                    targetedCategoryID: $targetedCategoryID,
+                                    moveCategory: { sourceID, destinationID in
+                                        categoryStore.moveCategory(sourceID, to: destinationID)
+                                    },
+                                    clearDragState: {
+                                        clearDragState()
+                                    }
+                                )
+                            )
+                            .animation(.spring(response: 0.28, dampingFraction: 0.82), value: categoryStore.visibleCategories.map(\.id))
+                            .onDisappear {
+                                if draggedCategoryID == category.id {
+                                    clearDragState()
+                                } else {
+                                    targetedCategoryID = nil
+                                }
+                            }
+                    }
+                }
             }
         }
+    }
+
+    private func managementTile(for category: FinanceCategory, isHiddenSection: Bool) -> CategoryManagementTile {
+        CategoryManagementTile(
+            category: category,
+            isTargeted: draggedCategoryID != nil && targetedCategoryID == category.id,
+            isHidden: isHiddenSection,
+            canReset: !category.isCustom && categoryStore.hasBuiltInOverride(for: category.id),
+            onEdit: {
+                edit(category)
+            },
+            onHide: {
+                hide(category)
+            },
+            onRestore: {
+                restore(category)
+            },
+            onReset: {
+                categoryStore.resetBuiltInOverride(for: category.id)
+            }
+        )
+    }
+
+    private func edit(_ category: FinanceCategory) {
+        categoryToEdit = category
+        showingEditor = true
+    }
+
+    private func hide(_ category: FinanceCategory) {
+        categoryStore.hideCategory(category)
+        normalizeDefaultCategory()
+    }
+
+    private func restore(_ category: FinanceCategory) {
+        categoryStore.restoreCategory(category)
+    }
+
+    private func normalizeDefaultCategory() {
+        let preferredCategoryID = categoryStore.preferredCategoryID(for: settingsViewModel.defaultCategoryID)
+        if preferredCategoryID != settingsViewModel.defaultCategoryID {
+            settingsViewModel.defaultCategoryID = preferredCategoryID
+        }
+    }
+
+    private func clearDragState() {
+        draggedCategoryID = nil
+        targetedCategoryID = nil
     }
 }
 
 private struct CategoryEditorView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var categoryStore: CategoryStore
+    @EnvironmentObject private var settingsViewModel: SettingsViewModel
 
     let category: FinanceCategory?
 
@@ -160,6 +220,36 @@ private struct CategoryEditorView: View {
                     }
                     .padding(.vertical, 6)
                 }
+
+                if let category {
+                    Section("Actions") {
+                        if categoryStore.isHidden(category.id) {
+                            Button {
+                                categoryStore.restoreCategory(category)
+                                dismiss()
+                            } label: {
+                                Label("Restore Category", systemImage: "eye")
+                            }
+                        } else {
+                            Button(role: .destructive) {
+                                categoryStore.hideCategory(category)
+                                normalizeDefaultCategory()
+                                dismiss()
+                            } label: {
+                                Label("Remove from Pickers", systemImage: "eye.slash")
+                            }
+                        }
+
+                        if !category.isCustom && categoryStore.hasBuiltInOverride(for: category.id) {
+                            Button(role: .destructive) {
+                                categoryStore.resetBuiltInOverride(for: category.id)
+                                dismiss()
+                            } label: {
+                                Label("Reset to Defaults", systemImage: "arrow.counterclockwise")
+                            }
+                        }
+                    }
+                }
             }
             .navigationTitle(category == nil ? "New Category" : "Edit Category")
             .navigationBarTitleDisplayMode(.inline)
@@ -200,12 +290,182 @@ private struct CategoryEditorView: View {
 
         dismiss()
     }
+
+    private func normalizeDefaultCategory() {
+        let preferredCategoryID = categoryStore.preferredCategoryID(for: settingsViewModel.defaultCategoryID)
+        if preferredCategoryID != settingsViewModel.defaultCategoryID {
+            settingsViewModel.defaultCategoryID = preferredCategoryID
+        }
+    }
+}
+
+private struct CategoryManagementTile: View {
+    let category: FinanceCategory
+    let isTargeted: Bool
+    let isHidden: Bool
+    let canReset: Bool
+    let onEdit: () -> Void
+    let onHide: () -> Void
+    let onRestore: () -> Void
+    let onReset: () -> Void
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ZStack(alignment: .topTrailing) {
+                Circle()
+                    .fill(category.color)
+                    .frame(width: 56, height: 56)
+
+                Image(systemName: category.iconName)
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundColor(.white)
+                    .frame(width: 56, height: 56)
+
+                menu
+                    .offset(x: 10, y: -10)
+            }
+
+            Text(category.displayName)
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundColor(isHidden ? .secondary : .primary)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.8)
+                .frame(height: 32)
+
+            if isHidden {
+                Button(action: onRestore) {
+                    Label("Restore", systemImage: "eye")
+                        .font(.caption2.weight(.semibold))
+                }
+                .buttonStyle(.borderless)
+            } else {
+                Image(systemName: "line.3.horizontal")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(minHeight: 124)
+        .padding(.vertical, 10)
+        .padding(.horizontal, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color(.secondarySystemGroupedBackground))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(isTargeted ? Color.accentColor : Color.clear, lineWidth: 2)
+        )
+        .opacity(isHidden ? 0.65 : 1)
+        .scaleEffect(isTargeted ? 1.03 : 1)
+        .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .onTapGesture(perform: onEdit)
+        .animation(.spring(response: 0.22, dampingFraction: 0.85), value: isTargeted)
+    }
+
+    private var menu: some View {
+        Menu {
+            Button(action: onEdit) {
+                Label("Edit", systemImage: "pencil")
+            }
+
+            if isHidden {
+                Button(action: onRestore) {
+                    Label("Restore", systemImage: "eye")
+                }
+            } else {
+                Button(role: .destructive, action: onHide) {
+                    Label("Remove", systemImage: "eye.slash")
+                }
+            }
+
+            if canReset {
+                Divider()
+
+                Button(role: .destructive, action: onReset) {
+                    Label("Reset", systemImage: "arrow.counterclockwise")
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle.fill")
+                .font(.system(size: 18, weight: .semibold))
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(Color.secondary, Color(.systemBackground))
+                .padding(6)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct CategoryDragPreview: View {
+    let category: FinanceCategory
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Circle()
+                .fill(category.color)
+                .frame(width: 52, height: 52)
+                .overlay {
+                    Image(systemName: category.iconName)
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundColor(.white)
+                }
+
+            Text(category.displayName)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color(.systemBackground))
+        )
+    }
+}
+
+private struct CategoryReorderDropDelegate: DropDelegate {
+    let destinationCategoryID: String
+    @Binding var draggedCategoryID: String?
+    @Binding var targetedCategoryID: String?
+    let moveCategory: (String, String) -> Void
+    let clearDragState: () -> Void
+
+    func dropEntered(info: DropInfo) {
+        guard let sourceCategoryID = draggedCategoryID,
+              sourceCategoryID != destinationCategoryID else {
+            return
+        }
+
+        targetedCategoryID = destinationCategoryID
+
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+            moveCategory(sourceCategoryID, destinationCategoryID)
+        }
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) {
+        if targetedCategoryID == destinationCategoryID {
+            targetedCategoryID = nil
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        clearDragState()
+        return true
+    }
 }
 
 #Preview {
     NavigationView {
         CategoryManagementView()
+            .environmentObject(SettingsViewModel())
             .environmentObject(CategoryStore())
     }
 }
-

--- a/iExpense/Views/EditExpenseView.swift
+++ b/iExpense/Views/EditExpenseView.swift
@@ -90,7 +90,7 @@ struct EditExpenseView: View {
                         CardView(title: "Category") {
                             CategoryGrid(
                                 selectedCategoryID: $selectedCategoryID,
-                                categories: categoryStore.allCategories
+                                categories: categoryStore.categoriesForPicker(including: selectedCategoryID)
                             )
                                 .padding(.horizontal)
                         }

--- a/iExpense/Views/EditExpenseView.swift
+++ b/iExpense/Views/EditExpenseView.swift
@@ -10,52 +10,36 @@ import SwiftUI
 struct EditExpenseView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.colorScheme) var colorScheme
+    @EnvironmentObject private var settingsViewModel: SettingsViewModel
+    @EnvironmentObject private var categoryStore: CategoryStore
     @ObservedObject var viewModel: ExpenseViewModel
 
     @State private var title: String
     @State private var price: String
     @State private var selectedDate: Date
-    @State private var selectedCategory: Category
+    @State private var selectedCategoryID: String
+    @State private var transactionType: TransactionType
     @State private var showDatePicker: Bool = false
     @State private var notes: String = ""
-    @State private var keyboardHeight: CGFloat = 0
     @State private var keyboardVisible: Bool = false
     @State private var viewID = UUID()
     let expense: Expense
 
     init(viewModel: ExpenseViewModel, expense: Expense) {
-        print("DEBUG: EditExpenseView init for expense ID \(expense.id.uuidString)")
         self.viewModel = viewModel
         self.expense = expense
         _title = State(initialValue: expense.title)
         _price = State(initialValue: String(format: "%.2f", expense.price))
         _selectedDate = State(initialValue: expense.date)
-        _selectedCategory = State(initialValue: expense.category)
-        
-        // Load notes directly from UserDefaults using expense ID as key
-        let notesKey = "notes_\(expense.id.uuidString)"
-        // List all the keys in UserDefaults to debug
-        print("DEBUG: ALL USERDEFAULTS KEYS:")
-        for key in UserDefaults.standard.dictionaryRepresentation().keys {
-            if key.starts(with: "notes_") {
-                let value = UserDefaults.standard.string(forKey: key) ?? "nil"
-                print("DEBUG:   - \(key) = \"\(value)\"")
-            }
-        }
-        
-        if let savedNotes = UserDefaults.standard.string(forKey: notesKey) {
-            print("DEBUG: Init - Found notes for key \(notesKey): \"\(savedNotes)\"")
-            _notes = State(initialValue: savedNotes)
-        } else {
-            print("DEBUG: Init - No notes found for key \(notesKey)")
-            _notes = State(initialValue: "")
-        }
+        _selectedCategoryID = State(initialValue: expense.categoryID)
+        _transactionType = State(initialValue: expense.type)
+        _notes = State(initialValue: expense.notes ?? "")
     }
 
     // Current currency symbol
     private var currencySymbol: String {
         let locale = Locale.current
-        let currencyCode = SettingsViewModel.getAppCurrency()
+        let currencyCode = settingsViewModel.selectedCurrency
         return locale.localizedCurrencySymbol(forCurrencyCode: currencyCode) ?? currencyCode
     }
 
@@ -68,12 +52,20 @@ struct EditExpenseView: View {
                 ScrollView {
                     VStack(spacing: 20) {
                         // Title and price card
-                        CardView(title: "Expense Details", showDivider: true) {
+                        CardView(title: "Transaction Details", showDivider: true) {
                             VStack(spacing: 16) {
+                                Picker("Type", selection: $transactionType) {
+                                    ForEach(TransactionType.allCases) { type in
+                                        Text(type.displayName).tag(type)
+                                    }
+                                }
+                                .pickerStyle(.segmented)
+                                .padding(.horizontal)
+
                                 TextFormField(
                                     label: "Title",
                                     text: $title,
-                                    placeholder: "Expense title"
+                                    placeholder: transactionType == .expense ? "Expense title" : "Income title"
                                 )
                                 .padding(.horizontal)
                                 
@@ -96,7 +88,10 @@ struct EditExpenseView: View {
                         
                         // Category selection
                         CardView(title: "Category") {
-                            CategoryGrid(selectedCategory: $selectedCategory)
+                            CategoryGrid(
+                                selectedCategoryID: $selectedCategoryID,
+                                categories: categoryStore.allCategories
+                            )
                                 .padding(.horizontal)
                         }
                         
@@ -116,15 +111,6 @@ struct EditExpenseView: View {
                                     .padding(8)
                                     .frame(minHeight: 100)
                                 
-                                // Display notes length for debugging
-                                Text("Notes length: \(notes.count)")
-                                    .font(.caption2)
-                                    .foregroundColor(.secondary)
-                                    .padding(4)
-                                    .background(Color(.systemBackground).opacity(0.7))
-                                    .cornerRadius(4)
-                                    .padding(8)
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                             }
                             .padding(.horizontal)
                             .padding(.bottom, 8)
@@ -165,7 +151,7 @@ struct EditExpenseView: View {
                             }) {
                                 let deleteButton: some View = HStack {
                                     Image(systemName: "trash.fill")
-                                    Text("Delete Expense")
+                                    Text("Delete Transaction")
                                 }
                                     .frame(maxWidth: .infinity)
                                     .padding(.vertical, 16)
@@ -184,11 +170,12 @@ struct EditExpenseView: View {
                         .padding(.top, 10)
                     }
                     .padding()
-                    .padding(.bottom, keyboardHeight > 0 ? keyboardHeight - 40 : 20)
+                    .padding(.bottom, 24)
                 }
+                .scrollDismissesKeyboard(.interactively)
             }
             .id(viewID)
-            .navigationTitle("Edit Expense")
+            .navigationTitle("Edit Transaction")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 // Cancel button
@@ -209,25 +196,16 @@ struct EditExpenseView: View {
             }
             .onAppear {
                 viewID = UUID()
-                
-                setupKeyboardObservers()
-                print("DEBUG: EditExpenseView appeared with notes: \"\(notes)\"")
-                
-                // Double check notes loading on appear
-                let notesKey = "notes_\(expense.id.uuidString)"
-                if let savedNotes = UserDefaults.standard.string(forKey: notesKey) {
-                    print("DEBUG: onAppear - Found notes for key \(notesKey): \"\(savedNotes)\"")
-                    // Force update notes if there's a mismatch
-                    if notes != savedNotes {
-                        notes = savedNotes
-                        print("DEBUG: onAppear - Updated notes to \"\(notes)\"")
-                    }
-                } else {
-                    print("DEBUG: onAppear - No notes found for key \(notesKey)")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+                withAnimation {
+                    keyboardVisible = true
                 }
             }
-            .onDisappear {
-                removeKeyboardObservers()
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+                withAnimation {
+                    keyboardVisible = false
+                }
             }
         }
     }
@@ -237,64 +215,32 @@ struct EditExpenseView: View {
     }
 
     private func saveChanges() {
-        print("DEBUG: Saving changes for expense ID \(expense.id.uuidString)")
         guard let priceValue = Double(price.replacingOccurrences(of: ",", with: ".")) else { return }
         
         if let index = viewModel.expenses.firstIndex(where: { $0.id == expense.id }) {
+            let selectedCategory = categoryStore.category(for: selectedCategoryID)
             viewModel.expenses[index].title = title
             viewModel.expenses[index].price = priceValue
             viewModel.expenses[index].date = selectedDate
-            viewModel.expenses[index].category = selectedCategory
+            viewModel.expenses[index].type = transactionType
+            viewModel.expenses[index].categoryID = selectedCategory.id
+            viewModel.expenses[index].category = Category.category(from: selectedCategory.id) ?? .others
+            let trimmedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+            viewModel.expenses[index].notes = trimmedNotes.isEmpty ? nil : trimmedNotes
             viewModel.saveExpenses()
-            
-            // Save notes to UserDefaults with expense ID as key
-            let notesKey = "notes_\(expense.id.uuidString)"
-            UserDefaults.standard.set(notes, forKey: notesKey)
-            UserDefaults.standard.synchronize()
-            print("DEBUG: Saved notes for key \(notesKey): \"\(notes)\"")
         }
     }
 
     private func deleteExpense() {
-        print("DEBUG: Deleting expense ID \(expense.id.uuidString)")
         if let index = viewModel.expenses.firstIndex(where: { $0.id == expense.id }) {
             viewModel.expenses.remove(at: index)
             viewModel.saveExpenses()
-            
-            // Remove notes from UserDefaults when expense is deleted
-            let notesKey = "notes_\(expense.id.uuidString)"
-            UserDefaults.standard.removeObject(forKey: notesKey)
-            UserDefaults.standard.synchronize()
-            print("DEBUG: Removed notes for key \(notesKey)")
         }
-    }
-    
-    // MARK: - Keyboard Handling
-    
-    private func setupKeyboardObservers() {
-        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { notification in
-            if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
-                self.keyboardHeight = keyboardFrame.height
-                withAnimation {
-                    self.keyboardVisible = true
-                }
-            }
-        }
-        
-        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
-            self.keyboardHeight = 0
-            withAnimation {
-                self.keyboardVisible = false
-            }
-        }
-    }
-    
-    private func removeKeyboardObservers() {
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 }
 
 #Preview {
     EditExpenseView(viewModel: ExpenseViewModel(), expense: Expense(title: "Sample", price: 10, date: Date(), category: .food))
+        .environmentObject(SettingsViewModel())
+        .environmentObject(CategoryStore())
 }

--- a/iExpense/Views/ExpensesListView.swift
+++ b/iExpense/Views/ExpensesListView.swift
@@ -6,26 +6,26 @@
 import SwiftUI
 
 struct ExpensesListView: View {
+    @EnvironmentObject private var settingsViewModel: SettingsViewModel
+    @EnvironmentObject private var categoryStore: CategoryStore
+
     @ObservedObject var viewModel: ExpenseViewModel
     @StateObject private var analyticsViewModel = AnalyticsViewModel(expenses: [])
 
     @State private var selectedMonth: Int = Calendar.current.component(.month, from: Date())
     @State private var selectedYear: Int = Calendar.current.component(.year, from: Date())
     @State private var recentlyDeletedExpenses: [Expense] = []
-    @State private var showUndoSnackbar: Bool = false
-    @State private var undoTimer: Timer? = nil
-    @State private var selectedExpenseToEdit: Expense? = nil
-    @State private var showingFilterSheet: Bool = false
+    @State private var showUndoSnackbar = false
+    @State private var undoTimer: Timer?
+    @State private var selectedExpenseToEdit: Expense?
+    @State private var showingFilterSheet = false
     @State private var selectedSortOption: SortOption = .dateDescending
-    @State private var searchText: String = ""
-    @State private var showEmptyState: Bool = false
-    @State private var selectedCategories: Set<Category> = Set(Category.allCases)
-    @State private var isSearchActive = false
-    
-    // Animation states
+    @State private var selectedTransactionFilter: TransactionFilter = .all
+    @State private var searchText = ""
+    @State private var selectedCategoryIDs: Set<String> = []
     @State private var isListLoaded = false
-    
-    private let monthHistoryLength = 61 // include current month plus ~5 years of history
+
+    private let monthHistoryLength = 61
 
     enum SortOption: String, CaseIterable, Identifiable {
         case dateDescending = "Newest First"
@@ -33,51 +33,86 @@ struct ExpensesListView: View {
         case amountDescending = "Highest Amount"
         case amountAscending = "Lowest Amount"
         case titleAscending = "Title A-Z"
-        
-        var id: String { self.rawValue }
+
+        var id: String { rawValue }
     }
-    
-    private var totalAmount: Double {
-        filteredExpenses.reduce(0) { $0 + $1.price }
+
+    enum TransactionFilter: String, CaseIterable, Identifiable {
+        case all = "All"
+        case expenses = "Expenses"
+        case incomes = "Incomes"
+
+        var id: String { rawValue }
+
+        func matches(_ transaction: Expense) -> Bool {
+            switch self {
+            case .all:
+                return true
+            case .expenses:
+                return transaction.type == .expense
+            case .incomes:
+                return transaction.type == .income
+            }
+        }
     }
-    
+
+    private var currencyCode: String {
+        settingsViewModel.selectedCurrency
+    }
+
     private var filteredExpenses: [Expense] {
         var result = viewModel.expenses.filter { expense in
             let month = Calendar.current.component(.month, from: expense.date)
             let year = Calendar.current.component(.year, from: expense.date)
+            let category = categoryStore.category(for: expense)
+
             let matchesDate = month == selectedMonth && year == selectedYear
-            let matchesSearch = searchText.isEmpty || 
+            let matchesSearch = searchText.isEmpty ||
                 expense.title.localizedCaseInsensitiveContains(searchText) ||
-                expense.category.displayName.localizedCaseInsensitiveContains(searchText)
-            let matchesCategory = selectedCategories.contains(expense.category)
-            
-            return matchesDate && matchesSearch && matchesCategory
+                category.displayName.localizedCaseInsensitiveContains(searchText) ||
+                (expense.notes?.localizedCaseInsensitiveContains(searchText) ?? false)
+            let matchesCategory = selectedCategoryIDs.isEmpty || selectedCategoryIDs.contains(expense.categoryID)
+            let matchesType = selectedTransactionFilter.matches(expense)
+
+            return matchesDate && matchesSearch && matchesCategory && matchesType
         }
-        
-        // Apply sorting
+
         switch selectedSortOption {
         case .dateDescending:
-            result.sort(by: { $0.date > $1.date })
+            result.sort { $0.date > $1.date }
         case .dateAscending:
-            result.sort(by: { $0.date < $1.date })
+            result.sort { $0.date < $1.date }
         case .amountDescending:
-            result.sort(by: { $0.price > $1.price })
+            result.sort { $0.price > $1.price }
         case .amountAscending:
-            result.sort(by: { $0.price < $1.price })
+            result.sort { $0.price < $1.price }
         case .titleAscending:
-            result.sort(by: { $0.title < $1.title })
+            result.sort { $0.title < $1.title }
         }
-        
+
         return result
     }
-    
-    private var groupedExpenses: [Category: [Expense]] {
-        Dictionary(grouping: filteredExpenses) { $0.category }
+
+    private var totalSpent: Double {
+        filteredExpenses.filter { $0.type == .expense }.reduce(0) { $0 + $1.price }
     }
-    
-    private var visibleCategories: [Category] {
-        let categories = Array(groupedExpenses.keys).sorted(by: { $0.displayName < $1.displayName })
-        return categories
+
+    private var totalIncome: Double {
+        filteredExpenses.filter { $0.type == .income }.reduce(0) { $0 + $1.price }
+    }
+
+    private var netCashflow: Double {
+        totalIncome - totalSpent
+    }
+
+    private var groupedExpenses: [String: [Expense]] {
+        Dictionary(grouping: filteredExpenses) { $0.categoryID }
+    }
+
+    private var visibleCategoryIDs: [String] {
+        groupedExpenses.keys.sorted {
+            categoryStore.category(for: $0).displayName < categoryStore.category(for: $1).displayName
+        }
     }
 
     var body: some View {
@@ -85,105 +120,38 @@ struct ExpensesListView: View {
             ZStack {
                 Color(.systemGroupedBackground)
                     .ignoresSafeArea()
-                
+
                 VStack(spacing: 0) {
-                    // Month Year Picker
                     monthYearPicker
                         .padding(.top, 8)
-                    
-                    // Summary Card
+
                     if !filteredExpenses.isEmpty {
                         summaryCard
                             .padding(.horizontal)
                             .padding(.top, 16)
                             .padding(.bottom, 8)
                     }
-                    
-                    // Main content
+
                     if filteredExpenses.isEmpty {
                         emptyStateView
                             .transition(.opacity)
                             .animation(.easeInOut, value: filteredExpenses.isEmpty)
                     } else {
-                        List {
-                            ForEach(visibleCategories, id: \.self) { category in
-                                Section {
-                                    ForEach(groupedExpenses[category] ?? []) { expense in
-                                        ExpenseRowContent(expense: expense, onEdit: { 
-                                            selectedExpenseToEdit = expense
-                                        }, onDelete: {
-                                            deleteExpenseByID(expense)
-                                        })
-                                    }
-                                } header: {
-                                    HStack {
-                                        // Fixed-width icon container
-                                        ZStack {
-                                            Circle()
-                                                .fill(category.color)
-                                                .frame(width: 28, height: 28)
-                                            
-                                            Image(systemName: categoryIcon(for: category))
-                                                .foregroundColor(.white)
-                                                .font(.caption)
-                                        }
-                                        
-                                        Text(category.displayName)
-                                            .font(.headline)
-                                        
-                                        Spacer()
-                                        
-                                        // Total for this category
-                                        let categoryTotal = (groupedExpenses[category] ?? []).reduce(0) { $0 + $1.price }
-                                        Text(categoryTotal, format: .currency(code: SettingsViewModel.getAppCurrency()))
-                                            .font(.subheadline)
-                                            .foregroundColor(.secondary)
-                                    }
-                                    .padding(.vertical, 6)
-                                }
-                            }
-                        }
-                        .listStyle(.insetGrouped)
-                        .opacity(isListLoaded ? 1 : 0)
-                        .animation(.easeIn(duration: 0.3), value: isListLoaded)
+                        transactionList
                     }
                 }
             }
-            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search expenses")
-            .onChange(of: searchText) {
-                withAnimation {
-                    isSearchActive = !searchText.isEmpty
-                }
-            }
-            .navigationTitle("Expenses")
+            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search transactions")
+            .navigationTitle("Transactions")
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    HStack(spacing: 12) {
-                        // Sort button
-                        Menu {
-                            Picker("Sort by", selection: $selectedSortOption) {
-                                ForEach(SortOption.allCases) { option in
-                                    Text(option.rawValue).tag(option)
-                                }
-                            }
-                        } label: {
-                            Label("Sort", systemImage: "arrow.up.arrow.down")
-                        }
-                        
-                        // Filter button
-                        Button(action: {
-                            showingFilterSheet = true
-                        }) {
-                            Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
-                        }
-                    }
+                    toolbarFilters
                 }
-                
+
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: {
-                        let newExpense = Expense(title: "", price: 0, date: Date(), category: .food)
-                        selectedExpenseToEdit = newExpense
-                    }) {
+                    Button {
+                        selectedExpenseToEdit = Expense(title: "", price: 0, date: Date(), category: .food)
+                    } label: {
                         Image(systemName: "plus")
                     }
                 }
@@ -193,8 +161,10 @@ struct ExpensesListView: View {
             }
             .onAppear {
                 analyticsViewModel.updateExpenses(viewModel.expenses)
-                
-                // Animate list appearance
+                if selectedCategoryIDs.isEmpty {
+                    selectedCategoryIDs = Set(categoryStore.allCategories.map(\.id))
+                }
+
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     withAnimation {
                         isListLoaded = true
@@ -206,55 +176,98 @@ struct ExpensesListView: View {
             }
             .sheet(item: $selectedExpenseToEdit) { expenseToEdit in
                 if expenseToEdit.title.isEmpty {
-                    // This is a new expense
                     AddExpenseView(viewModel: viewModel)
                 } else {
-                    // Use ID parameter to force view refresh
                     EditExpenseView(viewModel: viewModel, expense: expenseToEdit)
-                        .id(expenseToEdit.id) // Force view to refresh completely on each presentation
+                        .id(expenseToEdit.id)
                 }
             }
             .sheet(isPresented: $showingFilterSheet) {
-                FilterCategoriesView(selectedCategories: $selectedCategories)
+                FilterCategoriesView(selectedCategoryIDs: $selectedCategoryIDs)
                     .presentationDetents([.medium])
             }
-            .overlay(
-                VStack {
-                    Spacer()
-                    if showUndoSnackbar {
-                        HStack {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(.green)
-                            
-                            Text("Expense deleted")
-                                .foregroundColor(.white)
-                            
-                            Spacer()
-                            
-                            Button("Undo") {
-                                undoDelete()
-                            }
-                            .foregroundColor(.yellow)
-                            .fontWeight(.bold)
-                        }
-                        .padding()
-                        .background(
-                            RoundedRectangle(cornerRadius: 16)
-                                .fill(Color.black.opacity(0.85))
-                                .shadow(color: Color.black.opacity(0.2), radius: 5, x: 0, y: 2)
-                        )
-                        .padding(.horizontal)
-                        .padding(.bottom, 8)
-                        .transition(.move(edge: .bottom).combined(with: .opacity))
-                        .animation(.spring(), value: showUndoSnackbar)
-                    }
-                }
-            )
+            .overlay(undoSnackbar, alignment: .bottom)
         }
     }
-    
-    // MARK: - Month-Year Picker
-    
+
+    private var transactionList: some View {
+        List {
+            ForEach(visibleCategoryIDs, id: \.self) { categoryID in
+                let category = categoryStore.category(for: categoryID)
+
+                Section {
+                    ForEach(groupedExpenses[categoryID] ?? []) { expense in
+                        ExpenseRowContent(
+                            expense: expense,
+                            currencyCode: currencyCode,
+                            onEdit: {
+                                selectedExpenseToEdit = expense
+                            },
+                            onDelete: {
+                                deleteExpenseByID(expense)
+                            }
+                        )
+                    }
+                } header: {
+                    HStack {
+                        Image(systemName: category.iconName)
+                            .foregroundColor(.white)
+                            .font(.caption)
+                            .frame(width: 28, height: 28)
+                            .background(category.color)
+                            .clipShape(Circle())
+
+                        Text(category.displayName)
+                            .font(.headline)
+
+                        Spacer()
+
+                        let categoryTotal = (groupedExpenses[categoryID] ?? []).reduce(0) { total, transaction in
+                            total + (transaction.type == .income ? transaction.price : -transaction.price)
+                        }
+                        Text(categoryTotal, format: .currency(code: currencyCode))
+                            .font(.subheadline)
+                            .foregroundColor(categoryTotal >= 0 ? .green : .secondary)
+                    }
+                    .padding(.vertical, 6)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .opacity(isListLoaded ? 1 : 0)
+        .animation(.easeIn(duration: 0.3), value: isListLoaded)
+    }
+
+    private var toolbarFilters: some View {
+        HStack(spacing: 12) {
+            Menu {
+                Picker("Sort by", selection: $selectedSortOption) {
+                    ForEach(SortOption.allCases) { option in
+                        Text(option.rawValue).tag(option)
+                    }
+                }
+            } label: {
+                Label("Sort", systemImage: "arrow.up.arrow.down")
+            }
+
+            Menu {
+                Picker("Type", selection: $selectedTransactionFilter) {
+                    ForEach(TransactionFilter.allCases) { filter in
+                        Text(filter.rawValue).tag(filter)
+                    }
+                }
+            } label: {
+                Label("Type", systemImage: "line.3.horizontal.decrease")
+            }
+
+            Button {
+                showingFilterSheet = true
+            } label: {
+                Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
+            }
+        }
+    }
+
     private var monthYearPicker: some View {
         MonthYearPicker(
             selectedMonth: $selectedMonth,
@@ -264,80 +277,28 @@ struct ExpensesListView: View {
         .padding(.horizontal)
     }
 
-
-    
-    // MARK: - Summary Card
-    
     private var summaryCard: some View {
         VStack(spacing: 16) {
-            // Total amount for selected month
             HStack(spacing: 12) {
-                VStack(alignment: .leading,     spacing: 4) {
-                    Text("Total for \(Calendar.current.monthSymbols[selectedMonth - 1])")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                    
-                    Text(totalAmount, format: .currency(code: SettingsViewModel.getAppCurrency()))
-                        .font(.title2)
-                        .fontWeight(.bold)
-                }
-                
-                Spacer()
-                
-                // Number of expenses
+                summaryMetric(title: "Income", amount: totalIncome, color: .green)
+                Divider()
+                summaryMetric(title: "Spent", amount: totalSpent, color: .primary)
+                Divider()
+                summaryMetric(title: "Net", amount: netCashflow, color: netCashflow >= 0 ? .green : .red)
+                Divider()
                 VStack(alignment: .trailing, spacing: 4) {
-                    Text("Expenses")
+                    Text("Items")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
-                    
+
                     Text("\(filteredExpenses.count)")
-                        .font(.title2)
+                        .font(.title3)
                         .fontWeight(.bold)
                 }
             }
-            
-            // Budget progress if available
+
             if analyticsViewModel.currentBudget > 0 {
-                VStack(spacing: 6) {
-                    HStack {
-                        Text("Monthly Budget")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        
-                        Spacer()
-                        
-                        Text(totalAmount, format: .currency(code: SettingsViewModel.getAppCurrency()))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        
-                        Text("of")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        
-                        Text(analyticsViewModel.currentBudget, format: .currency(code: SettingsViewModel.getAppCurrency()))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    
-                    // Progress bar
-                    let progress = min(1.0, totalAmount / analyticsViewModel.currentBudget)
-                    let progressColor: Color = progress < 0.75 ? .blue : (progress < 0.9 ? .orange : .red)
-                    
-                    GeometryReader { geometry in
-                        ZStack(alignment: .leading) {
-                            // Background
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(Color(.systemGray5))
-                                .frame(height: 6)
-                            
-                            // Progress
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(progressColor)
-                                .frame(width: geometry.size.width * CGFloat(progress), height: 6)
-                        }
-                    }
-                    .frame(height: 6)
-                }
+                budgetProgress
             }
         }
         .padding()
@@ -347,36 +308,90 @@ struct ExpensesListView: View {
                 .shadow(color: Color.black.opacity(0.05), radius: 5, x: 0, y: 2)
         )
     }
-    
-    // MARK: - Empty State View
-    
+
+    private func summaryMetric(title: String, amount: Double, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            Text(amount, format: .currency(code: currencyCode))
+                .font(.title3)
+                .fontWeight(.bold)
+                .foregroundColor(color)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var budgetProgress: some View {
+        VStack(spacing: 6) {
+            HStack {
+                Text("Monthly Budget")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Spacer()
+
+                Text(totalSpent, format: .currency(code: currencyCode))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Text("of")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Text(analyticsViewModel.currentBudget, format: .currency(code: currencyCode))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            let progress = min(1.0, totalSpent / analyticsViewModel.currentBudget)
+            let progressColor: Color = progress < 0.75 ? .blue : (progress < 0.9 ? .orange : .red)
+
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color(.systemGray5))
+                        .frame(height: 6)
+
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(progressColor)
+                        .frame(width: geometry.size.width * CGFloat(progress), height: 6)
+                }
+            }
+            .frame(height: 6)
+        }
+    }
+
     private var emptyStateView: some View {
         VStack(spacing: 20) {
             Image(systemName: "doc.text.magnifyingglass")
                 .font(.system(size: 70))
                 .foregroundColor(.gray.opacity(0.6))
                 .padding()
-            
-            Text("No Expenses Found")
+
+            Text("No Transactions Found")
                 .font(.title2)
                 .fontWeight(.bold)
-            
+
             if !searchText.isEmpty {
                 Text("Try adjusting your search or filters")
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 40)
-            } else if selectedCategories.count < Category.allCases.count {
+            } else if selectedCategoryIDs.count < categoryStore.allCategories.count {
                 Text("Try selecting more categories in the filter")
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 40)
-                
-                Button(action: {
-                    selectedCategories = Set(Category.allCases)
-                }) {
+
+                Button {
+                    selectedCategoryIDs = Set(categoryStore.allCategories.map(\.id))
+                } label: {
                     Text("Reset Filters")
                         .foregroundColor(.accentColor)
                         .padding(.vertical, 8)
@@ -388,31 +403,28 @@ struct ExpensesListView: View {
                 }
                 .padding(.top, 8)
             } else {
-                Text("Add your first expense for \(Calendar.current.monthSymbols[selectedMonth - 1]) \(String(selectedYear))")
+                Text("Add your first transaction for \(Calendar.current.monthSymbols[selectedMonth - 1]) \(String(selectedYear))")
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 40)
-                
-                Button(action: {
-                    let newExpense = Expense(title: "", price: 0, date: Date(), category: .food)
-                    selectedExpenseToEdit = newExpense
-                }) {
+
+                Button {
+                    selectedExpenseToEdit = Expense(title: "", price: 0, date: Date(), category: .food)
+                } label: {
                     let addExpenseLabel: some View =
-                        Label("Add Expense", systemImage: "plus")
+                        Label("Add Transaction", systemImage: "plus")
                             .foregroundColor(.white)
                             .padding(.vertical, 10)
                             .padding(.horizontal, 20)
-                    
+
                     if #available(iOS 26.0, *) {
                         addExpenseLabel
                             .glassEffect(.regular.tint(.blue).interactive())
-                        
                     } else {
                         addExpenseLabel
                             .background(Color.accentColor)
                             .cornerRadius(10)
-
                     }
                 }
                 .padding(.top, 8)
@@ -421,7 +433,40 @@ struct ExpensesListView: View {
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
-    
+
+    private var undoSnackbar: some View {
+        VStack {
+            Spacer()
+            if showUndoSnackbar {
+                HStack {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+
+                    Text("Transaction deleted")
+                        .foregroundColor(.white)
+
+                    Spacer()
+
+                    Button("Undo") {
+                        undoDelete()
+                    }
+                    .foregroundColor(.yellow)
+                    .fontWeight(.bold)
+                }
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(Color.black.opacity(0.85))
+                        .shadow(color: Color.black.opacity(0.2), radius: 5, x: 0, y: 2)
+                )
+                .padding(.horizontal)
+                .padding(.bottom, 8)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .animation(.spring(), value: showUndoSnackbar)
+            }
+        }
+    }
+
     private func refreshExpenses() {
         viewModel.loadExpenses()
     }
@@ -431,9 +476,9 @@ struct ExpensesListView: View {
             recentlyDeletedExpenses = [expense]
             viewModel.expenses.remove(at: index)
             viewModel.saveExpenses()
-            
+
             showUndoSnackbar = true
-            
+
             undoTimer?.invalidate()
             undoTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { _ in
                 showUndoSnackbar = false
@@ -441,7 +486,7 @@ struct ExpensesListView: View {
             }
         }
     }
-    
+
     private func undoDelete() {
         undoTimer?.invalidate()
         viewModel.expenses.append(contentsOf: recentlyDeletedExpenses)
@@ -449,47 +494,20 @@ struct ExpensesListView: View {
         recentlyDeletedExpenses.removeAll()
         showUndoSnackbar = false
     }
-    
-    private func categoryIcon(for category: Category) -> String {
-        switch category {
-        case .food:
-            return "cart.fill"
-        case .eatingOut:
-            return "fork.knife"
-        case .rent:
-            return "house.fill"
-        case .shopping:
-            return "bag.fill"
-        case .entertainment:
-            return "tv.fill"
-        case .transportation:
-            return "car.fill"
-        case .utilities:
-            return "bolt.fill"
-        case .subscriptions:
-            return "repeat"
-        case .healthcare:
-            return "heart.fill"
-        case .education:
-            return "book.fill"
-        case .others:
-            return "ellipsis"
-        }
-    }
 }
 
-// MARK: - Expense Row View
-
 struct ExpenseRowView: View {
+    @EnvironmentObject private var categoryStore: CategoryStore
+
     let expense: Expense
-    
+    let currencyCode: String
+
     var body: some View {
         HStack(spacing: 12) {
-            // Date column
             VStack(alignment: .center, spacing: 2) {
                 Text(dayNumber)
                     .font(.system(size: 18, weight: .semibold))
-                
+
                 Text(monthShort)
                     .font(.caption2)
                     .foregroundColor(.secondary)
@@ -499,46 +517,62 @@ struct ExpenseRowView: View {
             .padding(.vertical, 8)
             .background(Color(.tertiarySystemBackground))
             .cornerRadius(8)
-            
-            // Title and details
+
             VStack(alignment: .leading, spacing: 4) {
                 Text(expense.title)
                     .font(.headline)
                     .lineLimit(1)
-                
+
                 HStack(spacing: 6) {
-                    Image(systemName: "calendar")
+                    Image(systemName: category.iconName)
                         .font(.caption2)
+                        .foregroundColor(category.color)
+
+                    Text(category.displayName)
+                        .font(.caption)
                         .foregroundColor(.secondary)
-                    
+
+                    Text("•")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
                     Text(formattedDate)
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
             }
-            
+
             Spacer()
-            
-            // Price
-            Text(expense.price, format: .currency(code: SettingsViewModel.getAppCurrency()))
+
+            Text(amountText)
                 .font(.system(.headline, design: .rounded))
                 .fontWeight(.bold)
+                .foregroundColor(expense.type.amountColor)
         }
         .padding(.vertical, 6)
     }
-    
+
+    private var category: FinanceCategory {
+        categoryStore.category(for: expense)
+    }
+
+    private var amountText: String {
+        let formatted = expense.price.formatted(.currency(code: currencyCode))
+        return expense.type == .income ? "+\(formatted)" : formatted
+    }
+
     private var dayNumber: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "d"
         return formatter.string(from: expense.date)
     }
-    
+
     private var monthShort: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "MMM"
         return formatter.string(from: expense.date)
     }
-    
+
     private var formattedDate: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "E, d MMM yyyy"
@@ -546,107 +580,57 @@ struct ExpenseRowView: View {
     }
 }
 
-// MARK: - Filter Categories View
-
 struct FilterCategoriesView: View {
-    @Binding var selectedCategories: Set<Category>
     @Environment(\.dismiss) private var dismiss
-    
-    @State private var tempSelectedCategories: Set<Category>
-    
-    init(selectedCategories: Binding<Set<Category>>) {
-        self._selectedCategories = selectedCategories
-        self._tempSelectedCategories = State(initialValue: selectedCategories.wrappedValue)
+    @EnvironmentObject private var categoryStore: CategoryStore
+
+    @Binding var selectedCategoryIDs: Set<String>
+    @State private var tempSelectedCategoryIDs: Set<String>
+
+    init(selectedCategoryIDs: Binding<Set<String>>) {
+        self._selectedCategoryIDs = selectedCategoryIDs
+        self._tempSelectedCategoryIDs = State(initialValue: selectedCategoryIDs.wrappedValue)
     }
-    
+
     var body: some View {
         NavigationView {
-            VStack {
-                List {
-                    Section {
-                        ForEach(Category.allCases, id: \.self) { category in
-                            HStack {
-                                // Fixed-width icon container
-                                ZStack {
-                                    Circle()
-                                        .fill(category.color)
-                                        .frame(width: 28, height: 28)
-                                    
-                                    Image(systemName: categoryIcon(for: category))
-                                        .foregroundColor(.white)
-                                        .font(.caption)
-                                }
-                                
-                                Text(category.displayName)
-                                    .font(.body)
-                                
-                                Spacer()
-                                
-                                if tempSelectedCategories.contains(category) {
-                                    Image(systemName: "checkmark")
-                                        .foregroundColor(.accentColor)
-                                }
-                            }
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                if tempSelectedCategories.contains(category) {
-                                    if tempSelectedCategories.count > 1 {  // Prevent removing all categories
-                                        tempSelectedCategories.remove(category)
-                                    }
-                                } else {
-                                    tempSelectedCategories.insert(category)
-                                }
+            List {
+                Section {
+                    ForEach(categoryStore.allCategories) { category in
+                        HStack {
+                            Image(systemName: category.iconName)
+                                .foregroundColor(.white)
+                                .font(.caption)
+                                .frame(width: 28, height: 28)
+                                .background(category.color)
+                                .clipShape(Circle())
+
+                            Text(category.displayName)
+                                .font(.body)
+
+                            Spacer()
+
+                            if tempSelectedCategoryIDs.contains(category.id) {
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(.accentColor)
                             }
                         }
-                    } header: {
-                        Text("Categories")
-                    } footer: {
-                        Text("Select which expense categories to display")
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            if tempSelectedCategoryIDs.contains(category.id) {
+                                if tempSelectedCategoryIDs.count > 1 {
+                                    tempSelectedCategoryIDs.remove(category.id)
+                                }
+                            } else {
+                                tempSelectedCategoryIDs.insert(category.id)
+                            }
+                        }
                     }
+                } header: {
+                    Text("Categories")
+                } footer: {
+                    Text("Select which categories to display")
                 }
-                
-//                HStack(spacing: 12) {
-//                    Button {
-//                        tempSelectedCategories = Set(Category.allCases)
-//                    } label: {
-//                        let selectAllButton: some View = Text("Select All")
-//                            .frame(maxWidth: .infinity)
-//                            .padding(.vertical, 12)
-//                        if #available(iOS 26.0, *) {
-//                            selectAllButton
-//                                .foregroundColor(.white)
-//                                .glassEffect(.regular.tint(.blue).interactive())
-//                        } else {
-//                            selectAllButton
-//                                .foregroundColor(.accentColor)
-//                                .background(
-//                                    RoundedRectangle(cornerRadius: 10)
-//                                        .stroke(Color.accentColor, lineWidth: 1)
-//                                )
-//                        }
-//                    }
-//                    
-//                    Button {
-//                        selectedCategories = tempSelectedCategories
-//                        dismiss()
-//                    } label: {
-//                        let applyButton: some View = Text("Apply")
-//                            .foregroundColor(.white)
-//                            .padding(.vertical, 12)
-//                            .frame(maxWidth: .infinity)
-//                        if #available(iOS 26.0, *) {
-//                            applyButton
-//                                .glassEffect(.regular.tint(.blue).interactive())
-//                        } else {
-//                            applyButton
-//                                .background(
-//                                    RoundedRectangle(cornerRadius: 10)
-//                                        .fill(Color.accentColor)
-//                                )
-//                        }
-//                    }
-//                }
-//                .padding()
             }
             .navigationTitle("Filter")
             .navigationBarTitleDisplayMode(.inline)
@@ -656,83 +640,46 @@ struct FilterCategoriesView: View {
                         dismiss()
                     }
                 }
-                
+
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Apply") {
-                        selectedCategories = tempSelectedCategories
+                        selectedCategoryIDs = tempSelectedCategoryIDs
                         dismiss()
                     }
-                    
                 }
             }
-        }
-    }
-    
-    private func categoryIcon(for category: Category) -> String {
-        switch category {
-        case .food:
-            return "cart.fill"
-        case .eatingOut:
-            return "fork.knife"
-        case .rent:
-            return "house.fill"
-        case .shopping:
-            return "bag.fill"
-        case .entertainment:
-            return "tv.fill"
-        case .transportation:
-            return "car.fill"
-        case .utilities:
-            return "bolt.fill"
-        case .subscriptions:
-            return "repeat"
-        case .healthcare:
-            return "heart.fill"
-        case .education:
-            return "book.fill"
-        case .others:
-            return "ellipsis"
         }
     }
 }
 
 struct ExpenseRowContent: View {
     let expense: Expense
+    let currencyCode: String
     let onEdit: () -> Void
     let onDelete: () -> Void
-    
+
     var body: some View {
-        ExpenseRowView(expense: expense)
+        ExpenseRowView(expense: expense, currencyCode: currencyCode)
             .contentShape(Rectangle())
             .onTapGesture {
-                print("DEBUG: Tap gesture on expense with ID \(expense.id), title \(expense.title)")
                 onEdit()
-                print("DEBUG: Directly setting selectedExpenseToEdit")
             }
             .contextMenu {
-                Button(action: {
-                    onEdit()
-                }) {
+                Button(action: onEdit) {
                     Label("Edit", systemImage: "pencil")
                 }
-                
-                Button(role: .destructive, action: {
-                    onDelete()
-                }) {
+
+                Button(role: .destructive, action: onDelete) {
                     Label("Delete", systemImage: "trash")
                 }
             }
             .swipeActions(edge: .leading) {
-                Button(role: .destructive) {
-                    onDelete()
-                } label: {
+                Button(role: .destructive, action: onDelete) {
                     Label("Delete", systemImage: "trash")
                 }
             }
             .swipeActions(edge: .trailing) {
-                Button {
-                    onEdit()
-                } label: {
+                Button(action: onEdit) {
                     Label("Edit", systemImage: "pencil")
                 }
                 .tint(.blue)
@@ -742,4 +689,7 @@ struct ExpenseRowContent: View {
 
 #Preview {
     ExpensesListView(viewModel: ExpenseViewModel())
+        .environmentObject(SettingsViewModel())
+        .environmentObject(CategoryStore())
 }
+

--- a/iExpense/Views/ExpensesListView.swift
+++ b/iExpense/Views/ExpensesListView.swift
@@ -109,10 +109,16 @@ struct ExpensesListView: View {
         Dictionary(grouping: filteredExpenses) { $0.categoryID }
     }
 
+    private var filterCategories: [FinanceCategory] {
+        categoryStore.categoriesForFilter(usedCategoryIDs: Set(viewModel.expenses.map(\.categoryID)))
+    }
+
+    private var filterCategoryIDs: [String] {
+        filterCategories.map(\.id)
+    }
+
     private var visibleCategoryIDs: [String] {
-        groupedExpenses.keys.sorted {
-            categoryStore.category(for: $0).displayName < categoryStore.category(for: $1).displayName
-        }
+        categoryStore.orderedCategoryIDs(for: Set(groupedExpenses.keys))
     }
 
     var body: some View {
@@ -162,7 +168,7 @@ struct ExpensesListView: View {
             .onAppear {
                 analyticsViewModel.updateExpenses(viewModel.expenses)
                 if selectedCategoryIDs.isEmpty {
-                    selectedCategoryIDs = Set(categoryStore.allCategories.map(\.id))
+                    selectedCategoryIDs = Set(filterCategoryIDs)
                 }
 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -171,11 +177,8 @@ struct ExpensesListView: View {
                     }
                 }
             }
-            .onChange(of: categoryStore.allCategories.map(\.id)) { oldCategoryIDs, newCategoryIDs in
-                let oldSet = Set(oldCategoryIDs)
-                let newSet = Set(newCategoryIDs)
-                selectedCategoryIDs.formUnion(newSet.subtracting(oldSet))
-                selectedCategoryIDs = selectedCategoryIDs.intersection(newSet)
+            .onChange(of: filterCategoryIDs) { oldCategoryIDs, newCategoryIDs in
+                syncSelectedCategoryIDs(oldCategoryIDs: oldCategoryIDs, newCategoryIDs: newCategoryIDs)
             }
             .onChange(of: viewModel.expenses) {
                 analyticsViewModel.updateExpenses(viewModel.expenses)
@@ -189,7 +192,7 @@ struct ExpensesListView: View {
                 }
             }
             .sheet(isPresented: $showingFilterSheet) {
-                FilterCategoriesView(selectedCategoryIDs: $selectedCategoryIDs)
+                FilterCategoriesView(selectedCategoryIDs: $selectedCategoryIDs, categories: filterCategories)
                     .presentationDetents([.medium])
             }
             .overlay(undoSnackbar, alignment: .bottom)
@@ -242,6 +245,13 @@ struct ExpensesListView: View {
         .listStyle(.insetGrouped)
         .opacity(isListLoaded ? 1 : 0)
         .animation(.easeIn(duration: 0.3), value: isListLoaded)
+    }
+
+    private func syncSelectedCategoryIDs(oldCategoryIDs: [String], newCategoryIDs: [String]) {
+        let oldSet = Set(oldCategoryIDs)
+        let newSet = Set(newCategoryIDs)
+        selectedCategoryIDs.formUnion(newSet.subtracting(oldSet))
+        selectedCategoryIDs = selectedCategoryIDs.intersection(newSet)
     }
 
     private var toolbarFilters: some View {
@@ -388,7 +398,7 @@ struct ExpensesListView: View {
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 40)
-            } else if selectedCategoryIDs.count < categoryStore.allCategories.count {
+            } else if selectedCategoryIDs.count < filterCategoryIDs.count {
                 Text("Try selecting more categories in the filter")
                     .font(.body)
                     .foregroundColor(.secondary)
@@ -396,7 +406,7 @@ struct ExpensesListView: View {
                     .padding(.horizontal, 40)
 
                 Button {
-                    selectedCategoryIDs = Set(categoryStore.allCategories.map(\.id))
+                    selectedCategoryIDs = Set(filterCategoryIDs)
                 } label: {
                     Text("Reset Filters")
                         .foregroundColor(.accentColor)
@@ -588,13 +598,14 @@ struct ExpenseRowView: View {
 
 struct FilterCategoriesView: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var categoryStore: CategoryStore
 
     @Binding var selectedCategoryIDs: Set<String>
+    let categories: [FinanceCategory]
     @State private var tempSelectedCategoryIDs: Set<String>
 
-    init(selectedCategoryIDs: Binding<Set<String>>) {
+    init(selectedCategoryIDs: Binding<Set<String>>, categories: [FinanceCategory]) {
         self._selectedCategoryIDs = selectedCategoryIDs
+        self.categories = categories
         self._tempSelectedCategoryIDs = State(initialValue: selectedCategoryIDs.wrappedValue)
     }
 
@@ -602,7 +613,7 @@ struct FilterCategoriesView: View {
         NavigationView {
             List {
                 Section {
-                    ForEach(categoryStore.allCategories) { category in
+                    ForEach(categories) { category in
                         HStack {
                             Image(systemName: category.iconName)
                                 .foregroundColor(.white)
@@ -698,4 +709,3 @@ struct ExpenseRowContent: View {
         .environmentObject(SettingsViewModel())
         .environmentObject(CategoryStore())
 }
-

--- a/iExpense/Views/ExpensesListView.swift
+++ b/iExpense/Views/ExpensesListView.swift
@@ -171,6 +171,12 @@ struct ExpensesListView: View {
                     }
                 }
             }
+            .onChange(of: categoryStore.allCategories.map(\.id)) { oldCategoryIDs, newCategoryIDs in
+                let oldSet = Set(oldCategoryIDs)
+                let newSet = Set(newCategoryIDs)
+                selectedCategoryIDs.formUnion(newSet.subtracting(oldSet))
+                selectedCategoryIDs = selectedCategoryIDs.intersection(newSet)
+            }
             .onChange(of: viewModel.expenses) {
                 analyticsViewModel.updateExpenses(viewModel.expenses)
             }

--- a/iExpense/Views/HomeView.swift
+++ b/iExpense/Views/HomeView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 import Charts
 
 struct HomeView: View {
+    @EnvironmentObject private var settingsViewModel: SettingsViewModel
+    @EnvironmentObject private var categoryStore: CategoryStore
+
     @ObservedObject var viewModel: ExpenseViewModel
     @ObservedObject var analyticsViewModel: AnalyticsViewModel
     @State private var showingAddExpense = false
@@ -18,6 +21,10 @@ struct HomeView: View {
     @State private var showingEditExpense = false
     
     private let recentDaysToShow = 7
+
+    private var currencyCode: String {
+        settingsViewModel.selectedCurrency
+    }
     
     var body: some View {
         NavigationView {
@@ -71,15 +78,23 @@ struct HomeView: View {
         VStack(spacing: 16) {
             // Total display
             VStack(spacing: 4) {
-                Text("Total Spent This Month")
+                Text("Monthly Cashflow")
                     .font(.headline)
                     .foregroundColor(.secondary)
                 
-                Text(analyticsViewModel.totalSpent, format: .currency(code: SettingsViewModel.getAppCurrency()))
+                Text(analyticsViewModel.netCashflow, format: .currency(code: currencyCode))
                     .font(.system(size: 42, weight: .bold, design: .rounded))
-                    .foregroundColor(.primary)
+                    .foregroundColor(analyticsViewModel.netCashflow >= 0 ? .green : .red)
                     .minimumScaleFactor(0.6)
                     .lineLimit(1)
+            }
+
+            HStack {
+                cashflowMetric(title: "Income", amount: analyticsViewModel.totalIncome, color: .green)
+                Divider()
+                cashflowMetric(title: "Spent", amount: analyticsViewModel.totalSpent, color: .primary)
+                Divider()
+                cashflowMetric(title: "Net", amount: analyticsViewModel.netCashflow, color: analyticsViewModel.netCashflow >= 0 ? .green : .red)
             }
             
             // Budget information if available
@@ -264,14 +279,16 @@ struct HomeView: View {
                         HStack(spacing: 12) {
                             // Icon and category
                             HStack(spacing: 8) {
-                                Image(systemName: categoryIcon(for: category))
+                                    let categoryDetails = categoryStore.category(for: category)
+
+                                    Image(systemName: categoryDetails.iconName)
                                     .font(.system(size: 16))
                                     .foregroundColor(.white)
                                     .frame(width: 30, height: 30)
-                                    .background(category.color)
+                                    .background(categoryDetails.color)
                                     .cornerRadius(8)
                                 
-                                Text(category.displayName)
+                                Text(categoryDetails.displayName)
                                     .font(.subheadline)
                                     .fontWeight(.medium)
                             }
@@ -280,7 +297,7 @@ struct HomeView: View {
                             
                             // Amount and percentage
                             VStack(alignment: .trailing, spacing: 2) {
-                                Text(amount, format: .currency(code: SettingsViewModel.getAppCurrency()))
+                                Text(amount, format: .currency(code: currencyCode))
                                     .font(.subheadline)
                                     .fontWeight(.semibold)
                                 
@@ -314,7 +331,7 @@ struct HomeView: View {
     private var recentExpensesSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Text("Recent Expenses")
+                Text("Recent Transactions")
                     .font(.headline)
                 
                 Spacer()
@@ -333,7 +350,7 @@ struct HomeView: View {
             
             if showRecentExpenses {
                 if viewModel.expenses.isEmpty {
-                    Text("No expenses yet")
+                    Text("No transactions yet")
                         .foregroundColor(.secondary)
                         .frame(maxWidth: .infinity, alignment: .center)
                     
@@ -348,11 +365,13 @@ struct HomeView: View {
                         } label: {
                             HStack(spacing: 12) {
                                 // Category icon
-                                Image(systemName: categoryIcon(for: expense.category))
+                                    let category = categoryStore.category(for: expense)
+
+                                    Image(systemName: category.iconName)
                                     .font(.system(size: 14))
                                     .foregroundColor(.white)
                                     .frame(width: 28, height: 28)
-                                    .background(expense.category.color)
+                                    .background(category.color)
                                     .cornerRadius(6)
                                 
                                 // Title and date
@@ -370,10 +389,10 @@ struct HomeView: View {
                                 Spacer()
                                 
                                 // Amount
-                                Text(expense.price, format: .currency(code: SettingsViewModel.getAppCurrency()))
+                                Text(amountText(for: expense))
                                     .font(.subheadline)
                                     .fontWeight(.semibold)
-                                    .foregroundColor(.primary)
+                                    .foregroundColor(expense.type.amountColor)
                             }
                             .padding(.vertical, 8)
                         }
@@ -389,7 +408,7 @@ struct HomeView: View {
                         // Use NotificationCenter to notify MainTabView to switch to expenses tab
                         NotificationCenter.default.post(name: NSNotification.Name("SwitchToExpensesTab"), object: nil)
                     }) {
-                        let viewAllExpensesButton: some View = Text("View All Expenses")
+                        let viewAllExpensesButton: some View = Text("View All Transactions")
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .frame(maxWidth: .infinity)
@@ -424,31 +443,25 @@ struct HomeView: View {
     
     // MARK: - Helper Methods
     
-    private func categoryIcon(for category: Category) -> String {
-        switch category {
-        case .food:
-            return "cart.fill"
-        case .eatingOut:
-            return "fork.knife"
-        case .rent:
-            return "house.fill"
-        case .shopping:
-            return "bag.fill"
-        case .entertainment:
-            return "tv.fill"
-        case .transportation:
-            return "car.fill"
-        case .utilities:
-            return "bolt.fill"
-        case .subscriptions:
-            return "repeat"
-        case .healthcare:
-            return "heart.fill"
-        case .education:
-            return "book.fill"
-        case .others:
-            return "ellipsis"
+    private func cashflowMetric(title: String, amount: Double, color: Color) -> some View {
+        VStack(spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Text(amount, format: .currency(code: currencyCode))
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundColor(color)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
         }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func amountText(for expense: Expense) -> String {
+        let formatted = expense.price.formatted(.currency(code: currencyCode))
+        return expense.type == .income ? "+\(formatted)" : formatted
     }
 }
 
@@ -457,4 +470,6 @@ struct HomeView: View {
         viewModel: ExpenseViewModel(),
         analyticsViewModel: AnalyticsViewModel(expenses: [])
     )
+    .environmentObject(SettingsViewModel())
+    .environmentObject(CategoryStore())
 }

--- a/iExpense/Views/MainTabView.swift
+++ b/iExpense/Views/MainTabView.swift
@@ -31,7 +31,7 @@ struct MainTabView: View {
 
                 ExpensesListView(viewModel: viewModel)
                     .tabItem {
-                        Label("Expenses", systemImage: "list.bullet.rectangle.portrait.fill")
+                        Label("Transactions", systemImage: "list.bullet.rectangle.portrait.fill")
                     }
                     .tag(2)
 
@@ -41,6 +41,7 @@ struct MainTabView: View {
                     }
                     .tag(3)
             }
+            .id(settingsViewModel.selectedCurrency)
         }
         .preferredColorScheme(settingsViewModel.selectedTheme.colorScheme)
         .onAppear {

--- a/iExpense/Views/SettingsView.swift
+++ b/iExpense/Views/SettingsView.swift
@@ -8,6 +8,7 @@ import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @EnvironmentObject var settingsManager: SettingsViewModel
+    @EnvironmentObject private var categoryStore: CategoryStore
     
     @State private var showingImportFilePicker = false
     @State private var showingExportShareSheet = false
@@ -28,6 +29,9 @@ struct SettingsView: View {
                 
                 // Default Settings Section
                 defaultSettingsSection
+
+                // Category Management Section
+                categoriesSection
                 
                 // Data Management Section
                 dataManagementSection
@@ -109,20 +113,31 @@ struct SettingsView: View {
     }
     
     private var categoryPicker: some View {
-        Picker("Default Category", selection: $settingsManager.defaultCategory) {
-            ForEach(Category.allCases, id: \.self) { category in
+        Picker("Default Category", selection: $settingsManager.defaultCategoryID) {
+            ForEach(categoryStore.allCategories) { category in
                 categoryRow(for: category)
             }
         }
         .pickerStyle(.menu)
     }
     
-    private func categoryRow(for category: Category) -> some View {
+    private func categoryRow(for category: FinanceCategory) -> some View {
         HStack {
             Circle()
                 .fill(category.color)
                 .frame(width: 12, height: 12)
-            Text(category.displayName).tag(category)
+            Text(category.displayName)
+        }
+        .tag(category.id)
+    }
+
+    private var categoriesSection: some View {
+        Section(header: Text("Categories")) {
+            NavigationLink {
+                CategoryManagementView()
+            } label: {
+                Label("Manage Categories", systemImage: "square.grid.2x2")
+            }
         }
     }
     
@@ -262,4 +277,5 @@ struct ShareSheet: UIViewControllerRepresentable {
 #Preview {
     SettingsView()
         .environmentObject(SettingsViewModel())
+        .environmentObject(CategoryStore())
 }

--- a/iExpense/Views/SettingsView.swift
+++ b/iExpense/Views/SettingsView.swift
@@ -119,6 +119,12 @@ struct SettingsView: View {
             }
         }
         .pickerStyle(.menu)
+        .onAppear {
+            normalizeDefaultCategory()
+        }
+        .onChange(of: categoryStore.allCategories.map(\.id)) { _, _ in
+            normalizeDefaultCategory()
+        }
     }
     
     private func categoryRow(for category: FinanceCategory) -> some View {
@@ -129,6 +135,13 @@ struct SettingsView: View {
             Text(category.displayName)
         }
         .tag(category.id)
+    }
+
+    private func normalizeDefaultCategory() {
+        let preferredCategoryID = categoryStore.preferredCategoryID(for: settingsManager.defaultCategoryID)
+        if preferredCategoryID != settingsManager.defaultCategoryID {
+            settingsManager.defaultCategoryID = preferredCategoryID
+        }
     }
 
     private var categoriesSection: some View {

--- a/iExpense/iExpenseApp.swift
+++ b/iExpense/iExpenseApp.swift
@@ -16,6 +16,7 @@ struct iExpenseApp: App {
     }
     
     @StateObject private var settingsViewModel = SettingsViewModel()
+    @StateObject private var categoryStore = CategoryStore()
     
     var body: some Scene {
         WindowGroup {
@@ -27,6 +28,7 @@ struct iExpenseApp: App {
                     await SwiftDataProvider.shared.startMigration()
                 }
                 .environmentObject(settingsViewModel)
+                .environmentObject(categoryStore)
                 .preferredColorScheme(settingsViewModel.selectedTheme.colorScheme)
         }
     }

--- a/iExpenseWidgetExtension/iExpenseWidgetExtension.swift
+++ b/iExpenseWidgetExtension/iExpenseWidgetExtension.swift
@@ -65,12 +65,17 @@ func getMonthlyBudget() -> Double {
 struct ExpenseEntry: TimelineEntry {
     let date: Date
     let totalSpent: Double
+    let totalIncome: Double
     let spendingByCategory: [Category: Double]
     let monthlyBudget: Double
     
     // Computed properties for the widget
     var budgetRemaining: Double {
         max(0, monthlyBudget - totalSpent)
+    }
+
+    var netCashflow: Double {
+        totalIncome - totalSpent
     }
     
     var budgetProgress: Double {
@@ -113,7 +118,8 @@ struct ExpenseQuickAddProvider: AppIntentTimelineProvider {
     func placeholder(in context: Context) -> ExpenseEntry {
         ExpenseEntry(
             date: Date(), 
-            totalSpent: 0, 
+            totalSpent: 0,
+            totalIncome: 0,
             spendingByCategory: [:],
             monthlyBudget: 0
         )
@@ -143,16 +149,20 @@ struct ExpenseQuickAddProvider: AppIntentTimelineProvider {
             return month == currentMonth && year == currentYear
         }
 
-        let total = filteredExpenses.reduce(0) { $0 + $1.price }
+        let expenseTransactions = filteredExpenses.filter { $0.type == .expense }
+        let incomeTransactions = filteredExpenses.filter { $0.type == .income }
+        let total = expenseTransactions.reduce(0) { $0 + $1.price }
+        let incomeTotal = incomeTransactions.reduce(0) { $0 + $1.price }
 
         var categoryTotals: [Category: Double] = [:]
-        for expense in filteredExpenses {
+        for expense in expenseTransactions {
             categoryTotals[expense.category, default: 0] += expense.price
         }
 
         return ExpenseEntry(
             date: Date(), 
-            totalSpent: total, 
+            totalSpent: total,
+            totalIncome: incomeTotal,
             spendingByCategory: categoryTotals,
             monthlyBudget: monthlyBudget
         )
@@ -247,6 +257,13 @@ struct iExpenseWidgetEntryView: View {
                 Text("spent this month")
                     .font(.caption)
                     .foregroundColor(.secondary)
+
+                if entry.totalIncome > 0 {
+                    Text("Net \(entry.netCashflow, format: .currency(code: currencyCode))")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundColor(entry.netCashflow >= 0 ? .green : .red)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             
@@ -300,6 +317,29 @@ struct iExpenseWidgetEntryView: View {
             Text("spent this month")
                 .font(.headline)
                 .foregroundColor(.secondary)
+
+            if entry.totalIncome > 0 {
+                HStack(spacing: 16) {
+                    VStack {
+                        Text("Income")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text(entry.totalIncome, format: .currency(code: currencyCode))
+                            .font(.headline)
+                            .foregroundColor(.green)
+                    }
+
+                    VStack {
+                        Text("Net")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text(entry.netCashflow, format: .currency(code: currencyCode))
+                            .font(.headline)
+                            .foregroundColor(entry.netCashflow >= 0 ? .green : .red)
+                    }
+                }
+                .padding(.top, 4)
+            }
             
             // Budget visualization if available
             if entry.monthlyBudget > 0 {
@@ -430,6 +470,7 @@ extension ShapeStyle where Self == Color {
     ExpenseEntry(
         date: .now,
         totalSpent: 780.50,
+        totalIncome: 2400.00,
         spendingByCategory: [
             .food: 250.00,
             .shopping: 175.75,
@@ -447,6 +488,7 @@ extension ShapeStyle where Self == Color {
     ExpenseEntry(
         date: .now,
         totalSpent: 780.50,
+        totalIncome: 2400.00,
         spendingByCategory: [
             .food: 250.00,
             .shopping: 175.75,
@@ -464,6 +506,7 @@ extension ShapeStyle where Self == Color {
     ExpenseEntry(
         date: .now,
         totalSpent: 780.50,
+        totalIncome: 2400.00,
         spendingByCategory: [
             .food: 250.00,
             .shopping: 175.75,
@@ -474,4 +517,3 @@ extension ShapeStyle where Self == Color {
         monthlyBudget: 1000.00
     )
 }
-


### PR DESCRIPTION
## Description
Adds first-class income tracking, reusable custom categories, and live currency refresh behavior.

Main changes:
- Adds transaction type support for expense vs income.
- Extends existing expense storage to support transaction type, category IDs, and embedded notes while keeping legacy records compatible.
- Adds a unified custom category model and category manager with name, SF Symbol icon, and color.
- Updates add/edit flows to support Expense/Income selection.
- Updates Home, Transactions, Analytics, and widget logic to show income, spending, and net cashflow.
- Keeps budget calculations expense-only.
- Fixes the add/edit sheet keyboard padding issue by removing manual keyboard-height bottom padding.
